### PR TITLE
[Feature] StudyGroup 엔티티 및 GroupStatus Enum 작성 (연관관계 제외)

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/GroupStatus.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/GroupStatus.java
@@ -1,0 +1,8 @@
+package com.samsamhajo.deepground.studyGroup.entity;
+
+public enum GroupStatus {
+    RECRUITING,    // 모집 중
+    ONGOING,       // 진행 중
+    COMPLETED,     // 완료
+    CANCELLED      // 취소
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_groups")
 public class StudyGroup extends BaseEntity {
 
     @Id
@@ -29,7 +30,7 @@ public class StudyGroup extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "group_status", nullable = false)
-    private GroupStatus groupStatus;
+    private GroupStatus groupStatus = GroupStatus.RECRUITING;
 
     @Column(name = "study_start_date", nullable = false)
     private LocalDate studyStartDate;

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -1,0 +1,57 @@
+package com.samsamhajo.deepground.studyGroup.entity;
+
+import com.samsamhajo.deepground.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroup extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_group_id")
+    private Long id;
+
+    @Column(name = "chat_room_id", nullable = false)
+    private Long chatRoomId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "explanation", nullable = false, columnDefinition = "TEXT")
+    private String explanation;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "group_status", nullable = false)
+    private GroupStatus groupStatus;
+
+    @Column(name = "study_start_date", nullable = false)
+    private LocalDate studyStartDate;
+
+    @Column(name = "study_end_date", nullable = false)
+    private LocalDate studyEndDate;
+
+    @Column(name = "recruit_start_date", nullable = false)
+    private LocalDate recruitStartDate;
+
+    @Column(name = "recruit_end_date", nullable = false)
+    private LocalDate recruitEndDate;
+
+    @Column(name = "group_member_count", nullable = false)
+    private Integer groupMemberCount;
+
+    @Column(name = "founder_id", nullable = false)
+    private Long founderId;
+
+    @Column(name = "is_offline", nullable = false)
+    private Boolean isOffline;
+
+    @Column(name = "study_location")
+    private String studyLocation;
+}


### PR DESCRIPTION
## 📌 개요

- StudyGroup 관련 엔티티를 새로 작성했습니다.
- 그룹 상태(`group_status`)를 Enum 타입(`GroupStatus`)으로 관리하도록 변경했습니다.
- 모든 항목은 데이터 무결성을 위해 `NOT NULL` 제약 조건을 적용했습니다.

---

## 🛠️ 작업 내용

-  StudyGroup 엔티티 작성
    - 기본 키(`study_group_id`) 설정
    - 필수 필드 매핑 (`chat_room_id`, `title`, `explanation`, 등)
    - `explanation` 필드는 `TEXT` 타입으로 매핑
    - 모든 항목에 대해 `nullable = false` 설정
-  GroupStatus Enum 작성
    - RECRUITING(모집 중), ONGOING(진행 중), COMPLETED(완료), CANCELLED(취소) 4개 상태 정의
-  group_status를 `@Enumerated(EnumType.STRING)`으로 매핑
-  BaseEntity 상속 처리로 공통 필드 관리
-  isOffline(Boolean), studyLocation(Nullable) 필드 작성
-  관련 이슈 번호: #11

---

### (StudyGroup 엔티티 작성)

- StudyGroup 엔티티를 작성하여 스터디 그룹의 주요 정보(채팅방, 모집 일정, 인원 등)를 저장할 수 있도록 했습니다.
- 특히 `explanation` 필드는 TEXT 타입으로 선언하여 긴 설명을 수용할 수 있도록 했습니다.
- 모든 주요 컬럼은 `NOT NULL` 처리하여 데이터의 안정성을 확보했습니다.

---

### (GroupStatus Enum 도입)

- 그룹 상태를 문자열이 아닌 `Enum` 타입으로 관리해 가독성과 타입 안정성을 높였습니다.
- `EnumType.STRING`을 사용하여 데이터베이스에 명시적으로 상태 이름이 저장되도록 설정했습니다.

---

## 📌 차후 계획 (Optional)

- StudyGroup과 관련된 다른 엔티티(`StudyGroupMember`, `StudyGroupComment`, `StudyGroupReply`) 작업 예정
- 추후 GroupStatus를 기반으로 스터디 그룹 필터링 기능 추가 예정
- isOffline을 추후 Enum(ONLINE, OFFLINE) 타입으로 리팩토링할 가능성 검토

---

## 📌 테스트 케이스

-  기능 정상 동작 확인
-  새로운 의존성 추가 없음 (`build.gradle` 등 영향 없음)
-  코드 스타일 및 컨벤션 준수 확인
-  기존 테스트 통과 여부 확인

> 엔티티 레벨만 작성했기 때문에 직접적인 로직 테스트는 없지만, Entity Scan 및 Application Context 로딩 정상 확인하였습니다.

---

### 📌 기타 참고 사항

- StudyGroup 엔티티에 대한 추가 검증 로직(예: 기간 유효성 검사)은 추후 Validator 혹은 Service Layer 개발 시, 필요하다면 추가할 예정입니다.
- Enum 사용 시 DB와의 저장 값 매칭이 깨질 경우를 대비하여 Enum 변경 시 주의가 필요합니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.

- StudyGroup 및 GroupStatus가 명확히 구분되어 있는지 확인 부탁드립니다.
- `@Enumerated(EnumType.STRING)` 설정 누락 여부를 확인해주세요.
- 코드 스타일 및 필드 선언 순서 일관성을 검토해주세요.
- 향후 확장성을 고려한 설계가 이루어졌는지 봐주세요.

Closes #11 