### PR TITLE
[Feature] 멤버 스터디 스케줄 엔티티 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
@@ -1,0 +1,36 @@
+package com.samsamhajo.deepground.calendar.entity;
+
+import com.samsamhajo.deepground.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MemberStudySchedule extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_study_schedule_id")
+    private Long id;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "study_schedule_id")
+//    private StudySchedule studySchedule;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "member_id")
+//    private Member member;
+
+    @Column(name = "memo")
+    private String memo;
+
+    @Column(name = "is_available", nullable = false)
+    private Boolean isAvailable;
+
+    @Column(name = "is_important")
+    private Boolean isImportant;
+
+
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
@@ -2,12 +2,14 @@ package com.samsamhajo.deepground.calendar.entity;
 
 import com.samsamhajo.deepground.global.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "member_study_schedules")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberStudySchedule extends BaseEntity {
 
     @Id
@@ -26,11 +28,11 @@ public class MemberStudySchedule extends BaseEntity {
     @Column(name = "memo")
     private String memo;
 
-    @Column(name = "is_available", nullable = false)
+    @Column(name = "is_available")
     private Boolean isAvailable;
 
-    @Column(name = "is_important")
-    private Boolean isImportant;
+    @Column(name = "is_important", nullable = false)
+    private Boolean isImportant = false;
 
 
 }


### PR DESCRIPTION
## 📌 개요

* 스터디 참여자의 개인 일정 상태를 기록하기 위한 MemberStudySchedule 엔티티를 생성했습니다.  
* 각 스터디 일정에 대해 개별 구성원이 작성하는 메모, 참석 가능 여부, 중요 표시 등의 정보를 저장합니다.


## 🛠️ 작업 내용
- [x] MemberStudySchedule 엔티티 클래스 생성
- [x] 메모(`memo`), 가능 여부(`isAvailable`), 중요 표시(`isImportant`) 필드 추가
- [x] StudySchedule, Member와의 연관관계 설정 예정 (주석 처리)
- [x] 관련 이슈 번호 (#24)


### MemberStudySchedule 엔티티 생성

* 다음과 같은 필드로 구성되어 있습니다:
  - `memo`: 자유로운 텍스트 메모 입력 필드 (nullable)
  - `isAvailable`: 해당 스케줄에 참여 가능한지 여부 (필수값)
  - `isImportant`: 중요 여부 표시 (nullable)

## 📌 관련 이슈
- close #24

## 📌 차후 계획 (Optional)

* StudySchedule, Member 엔티티와의 다대일 연관관계 설정 예정 (`@ManyToOne`)
* 스터디 캘린더 기능에서 해당 엔티티를 통해 개인별 메모/참석 여부 정보를 표시할 예정


## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.