### PR TITLE
[Feature] StudyGroupMember 엔티티 구현 (연관관계 제외)

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
@@ -22,6 +22,6 @@ public class StudyGroupMember extends BaseEntity {
     @Column(name = "study_group_id", nullable = false)
     private Long studyGroupId;
 
-    @Column(name = "is_allowed")
+    @Column(name = "is_allowed", nullable = false)
     private Boolean isAllowed = false;
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
@@ -1,0 +1,27 @@
+package com.samsamhajo.deepground.studyGroup.entity;
+
+import com.samsamhajo.deepground.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_member_id")
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "study_group_id", nullable = false)
+    private Long studyGroupId;
+
+    @Column(name = "is_allowed")
+    private Boolean isAllowed = false;
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_group_members")
 public class StudyGroupMember extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## 📌 개요

- 스터디 그룹 참여자 정보를 저장하는 `StudyGroupMember` 엔티티를 생성하였습니다.
- 현재는 연관관계 없이 `memberId`, `studyGroupId`를 단순 필드(Long)로만 저장하며, 추후 연관관계 매핑은 별도 PR로 진행할 예정입니다.

---

## 🛠️ 작업 내용

-  `StudyGroupMember` 엔티티 클래스 생성
-  기본 키 `group_id`에 대한 ID 매핑 설정
-  `memberId`, `studyGroupId`를 단순 Long 타입으로 정의 (연관관계 미포함)
-  `isAllowed` 필드 정의 (nullable Boolean)
-  `BaseEntity` 상속으로 공통 필드 관리
-  관련 이슈 번호: #12

---

### StudyGroupMember 엔티티 필드 구성

- `group_id`: 참여 식별자 (PK)
- `member_id`: 참여 멤버 ID
- `study_group_id`: 참여 그룹 ID
- `is_allowed`: 참여 승인 여부 (nullable)

---

### 연관관계 제외 이유

- 현재 `Member`, `StudyGroup` 엔티티의 개발 브랜치와 충돌을 방지하기 위해  
    연관관계는 제거하고 ID만 저장하도록 구성하였습니다.
- 이후 `@ManyToOne` 등 연관관계 매핑은 안정화된 이후 별도 PR로 다룰 예정입니다.

---

## 📌 차후 계획 (Optional)

- 연관관계 매핑 (`StudyGroup` 및 `Member`와 `@ManyToOne`) 적용 PR 예정
- `StudyGroup` → `StudyGroupMember` 방향의 양방향 매핑 도입 고려

---

## 📌 테스트 케이스

-  Entity 스캔 및 Context 로딩 정상 확인
-  새로운 의존성 없음 (`build.gradle` 영향 없음)
-  코드 스타일 및 컨벤션 준수 확인

---

### 📌 기타 참고 사항

- 멤버 연관관계를 생략한 대신 ID(Long)로 단순 저장하여 충돌을 방지함
- 팀 내 다른 브랜치와의 merge conflict 예방을 위한 선제적 구조 설계

---

#### 🙏🏻 아래와 같이 PR을 리뷰해주세요.

- 불필요한 연관관계 설정이 없는지 확인해주세요.
- `BaseEntity` 상속 구조와 공통 컬럼 적용 여부 확인해주세요.
- 네이밍 및 필드 정의가 일관성 있게 작성되었는지 확인 부탁드립니다.
- 추후 연관관계 매핑을 위한 확장성 확보가 되어 있는지 확인해주세요.

Closes #12 