### PR TITLE
[Feature] StudyGroupComment 엔티티 구현 (연관관계 제외)

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupComment.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupComment.java
@@ -1,0 +1,27 @@
+package com.samsamhajo.deepground.studyGroup.entity;
+
+import com.samsamhajo.deepground.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(name = "study_group_id", nullable = false)
+    private Long studyGroupId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupComment.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupComment.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_group_comments")
 public class StudyGroupComment extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## 📌 개요

스터디 그룹 내 댓글을 저장하는 `StudyGroupComment` 엔티티를 생성하였습니다.  
현재는 연관관계 없이 `memberId`, `studyGroupId`를 Long 필드로만 저장합니다.

---

## 🛠️ 작업 내용

-  `StudyGroupComment` 엔티티 클래스 생성
-  `comment_id`를 기본 키로 설정
-  `studyGroupId`, `memberId`를 단일 Long 필드로 명시 (연관관계 제외)
-  `content` 필드를 `TEXT` 타입으로 선언
-  `BaseEntity` 상속
-  관련 이슈 번호: #13

---

### StudyGroupComment 엔티티 구조

- `comment_id`: 댓글 고유 ID
- `study_group_id`: 댓글이 달린 스터디 그룹 ID
- `member_id`: 댓글 작성자 ID
- `content`: 댓글 본문 (nullable 불가, TEXT)

---

## 📌 차후 계획 (Optional)

- `StudyGroup` 및 `Member`와의 연관관계 매핑 추가 예정 (`@ManyToOne`)
- 댓글에 대한 대댓글 기능 추가 시, `StudyGroupReply`와 연계 예정

---


## 📌 테스트 케이스

-  Entity 스캔 및 Context 로딩 정상 확인
-  새로운 의존성 없음 (`build.gradle` 영향 없음)
-  코드 스타일 및 컨벤션 준수 확인

---

### 📌 기타 참고 사항

- 연관관계가 제거되어 있어 테스트/기능 개발이 충돌 없이 진행 가능
- 추후 기능 연계 시 `@ManyToOne`으로 유연하게 확장 가능하도록 설계

---

#### 🙏🏻 아래와 같이 PR을 리뷰해주세요.

- `content` 필드에 대한 타입 및 null 허용 여부 검토해주세요.
- 네이밍, 포맷, 주석 등 팀 컨벤션과의 일관성 확인해주세요.

Closes #13 