### PR TITLE
[Feature] StudyGroupReply 엔티티 구현 (연관관계 제외)

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupReply.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupReply.java
@@ -1,0 +1,27 @@
+package com.samsamhajo.deepground.studyGroup.entity;
+
+import com.samsamhajo.deepground.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupReply extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_group_reply_id")
+    private Long id;
+
+    @Column(name = "comment_id", nullable = false)
+    private Long commentId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupReply.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupReply.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_group_replies")
 public class StudyGroupReply extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## 📌 개요

스터디 그룹 댓글에 대한 **대댓글을 저장**하는 `StudyGroupReply` 엔티티를 생성하였습니다.  
연관관계 없이 외래 키는 ID(Long)로만 저장하도록 구성하였습니다.

---

## 🛠️ 작업 내용

-  `StudyGroupReply` 엔티티 클래스 생성
-  기본 키 `study_group_reply_id` 매핑
-  댓글(comment), 멤버(member)는 단일 Long 타입으로 저장
-  `content`는 NOT NULL 필드로 선언
-  `BaseEntity` 상속 적용
-  관련 이슈 번호: #14 

---

### StudyGroupReply 엔티티 구조 설명

- `study_group_reply_id`: 대댓글 고유 ID
- `comment_id`: 연결된 댓글 ID
- `member_id`: 작성자 ID
- `content`: 대댓글 내용

---

## 📌 차후 계획 (Optional)

- 추후 `StudyGroupComment`와의 연관관계(`@ManyToOne`) 매핑 예정

---

## 📌 테스트 케이스

-  Entity 스캔 및 ApplicationContext 로딩 정상 확인
-  코드 컨벤션 및 스타일 점검 완료
-  신규 의존성 없음 (`build.gradle` 영향 없음)

---

### 📌 기타 참고 사항

- 연관관계 없이 ID만 사용하는 구조로 설계되어 현재 구조에서의 충돌을 피할 수 있음

---

#### 🙏🏻 아래와 같이 PR을 리뷰해주세요.

- `StudyGroupReply` 필드와 DB 스키마가 일치하는지 확인해주세요.
- `content`의 NOT NULL 여부가 팀의 정책과 맞는지 확인해주세요.
- 구조적 확장성(연관관계 도입 시 유연성) 여부 확인해주세요.
- 코드 네이밍, 어노테이션, 포맷이 일관성을 유지하고 있는지 검토해주세요.

Closes #14 