### PR TITLE
[Refactor] 캘린더 관련 정적 팩토리 메서드 추가 및 연관관계 매핑

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.calendar.entity;
 
 import com.samsamhajo.deepground.global.BaseEntity;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,13 +18,13 @@ public class MemberStudySchedule extends BaseEntity {
     @Column(name = "member_study_schedule_id")
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "study_schedule_id")
-//    private StudySchedule studySchedule;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_schedule_id")
+    private StudySchedule studySchedule;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "member_id")
-//    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @Column(name = "memo")
     private String memo;

--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
@@ -26,25 +26,32 @@ public class MemberStudySchedule extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(name = "memo")
-    private String memo;
-
     @Column(name = "is_available")
     private Boolean isAvailable;
 
     @Column(name = "is_important", nullable = false)
     private Boolean isImportant = false;
 
-    private MemberStudySchedule(StudySchedule studySchedule, Member member, String memo, Boolean isAvailable, Boolean isImportant) {
+    @Column(name = "memo")
+    private String memo;
+
+    private MemberStudySchedule(StudySchedule studySchedule, Member member, Boolean isAvailable, Boolean isImportant, String memo) {
         this.studySchedule = studySchedule;
         this.member = member;
-        this.memo = memo;
         this.isAvailable = isAvailable;
         this.isImportant = isImportant;
+        this.memo = memo;
+
     }
 
-    public static MemberStudySchedule of(StudySchedule studySchedule, Member member, String memo, Boolean isAvailable, Boolean isImportant) {
-        return new MemberStudySchedule(studySchedule, member, memo, isAvailable, isImportant);
+    // memo가 있는 경우
+    public static MemberStudySchedule of(StudySchedule studySchedule, Member member, Boolean isAvailable, Boolean isImportant, String memo) {
+        return new MemberStudySchedule(studySchedule, member, isAvailable, isImportant, memo);
+    }
+
+    // memo가 없는 경우
+    public static MemberStudySchedule of(StudySchedule studySchedule, Member member, Boolean isAvailable, Boolean isImportant) {
+        return new MemberStudySchedule(studySchedule, member, isAvailable, isImportant, "");
     }
 
 

--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
@@ -35,5 +35,17 @@ public class MemberStudySchedule extends BaseEntity {
     @Column(name = "is_important", nullable = false)
     private Boolean isImportant = false;
 
+    private MemberStudySchedule(StudySchedule studySchedule, Member member, String memo, Boolean isAvailable, Boolean isImportant) {
+        this.studySchedule = studySchedule;
+        this.member = member;
+        this.memo = memo;
+        this.isAvailable = isAvailable;
+        this.isImportant = isImportant;
+    }
+
+    public static MemberStudySchedule of(StudySchedule studySchedule, Member member, String memo, Boolean isAvailable, Boolean isImportant) {
+        return new MemberStudySchedule(studySchedule, member, memo, isAvailable, isImportant);
+    }
+
 
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/StudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/StudySchedule.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.calendar.entity;
 
 import com.samsamhajo.deepground.global.BaseEntity;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,10 +19,10 @@ public class StudySchedule extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "study_schedule_id")
     private Long id;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "study_group_id")
-//    private StudyGroup studyGroup;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_group_id")
+    private StudyGroup studyGroup;
 
     @Column(name = "schedule_title", nullable = false)
     private String title;

--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/StudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/StudySchedule.java
@@ -48,20 +48,15 @@ public class StudySchedule extends BaseEntity {
         this.location = location;
     }
 
-
-    // location 있는 경우
+    // location이 있는 경우
     public static StudySchedule of(StudyGroup studyGroup, String title, LocalDateTime startTime, LocalDateTime endTime, String description, String location) {
         return new StudySchedule(studyGroup, title, startTime, endTime, description, location);
     }
 
-
-    // location 없는 경우
+    // location이 없는 경우
     public static StudySchedule of(StudyGroup studyGroup, String title, LocalDateTime startTime, LocalDateTime endTime, String description) {
         return new StudySchedule(studyGroup, title, startTime, endTime, description, null);
     }
-
-
-
 
 
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/StudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/StudySchedule.java
@@ -33,10 +33,35 @@ public class StudySchedule extends BaseEntity {
     @Column(name = "end_time", nullable = false)
     private LocalDateTime endTime;
 
-    @Column(name = "description")
+    @Column(name = "description", nullable = false)
     private String description;
 
     @Column(name = "location")
     private String location;
+
+    private StudySchedule(StudyGroup studyGroup, String title, LocalDateTime startTime, LocalDateTime endTime, String description, String location) {
+        this.studyGroup = studyGroup;
+        this.title = title;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.description = description;
+        this.location = location;
+    }
+
+
+    // location 있는 경우
+    public static StudySchedule of(StudyGroup studyGroup, String title, LocalDateTime startTime, LocalDateTime endTime, String description, String location) {
+        return new StudySchedule(studyGroup, title, startTime, endTime, description, location);
+    }
+
+
+    // location 없는 경우
+    public static StudySchedule of(StudyGroup studyGroup, String title, LocalDateTime startTime, LocalDateTime endTime, String description) {
+        return new StudySchedule(studyGroup, title, startTime, endTime, description, null);
+    }
+
+
+
+
 
 }


### PR DESCRIPTION
## 📌 개요

* Calendar 도메인 내 StudySchedule, MemberStudySchedule 엔티티 간의 연관관계를 매핑했습니다.
*  다른 도메인(StudyGroup, Member)과의 연관관계도 함께 설정했습니다.
* 생성자를 private으로 변경하고, 정적 팩토리 메서드를 추가하여 객체 생성의 일관성을 유지했습니다.

## 🛠️ 작업 내용
- [x] StudySchedule에 StudyGroup과의 연관관계 매핑 추가
- [x] MemberStudySchedule에 StudySchedule, Member와의 연관관계 매핑 추가
- [x] 생성자 접근 제어 설정
- [x] 정적 팩토리 메서드(of) 추가
- [x] 관련 이슈 번호 (#45)


## 📌 차후 계획 (Optional)
* 연관관계를 활용한 서비스 및 API 구현 예정



## 📌 테스트 케이스
- [x] 기능 정상 동작 확인


### 📌 기타 참고 사항
의견 있으시면 편하게 남겨주세요

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #45