### PR TITLE
[Feature] 알림 엔티티 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/global/BaseDocument.java
+++ b/src/main/java/com/samsamhajo/deepground/global/BaseDocument.java
@@ -16,11 +16,4 @@ public abstract class BaseDocument {
     @LastModifiedDate
     @Field("modified_at")
     private LocalDateTime modifiedAt;
-
-    @Field("is_deleted")
-    private boolean deleted = false;
-
-    public void softDelete() {
-        this.deleted = true;
-    }
 }

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/Notification.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/Notification.java
@@ -1,0 +1,33 @@
+package com.samsamhajo.deepground.notification.entity;
+
+import com.samsamhajo.deepground.global.BaseDocument;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+@Document(collection = "notifications")
+@CompoundIndex(def = "{'receiver_id': 1, 'created_at': -1}")
+public class Notification extends BaseDocument {
+
+    @Id
+    @Field("notification_id")
+    private String id;
+
+    @Field("receiver_id")
+    private Long receiverId;
+
+    @DBRef
+    @Field("notification_message_id")
+    private NotificationMessage notificationMessage;
+
+    @Field("is_read")
+    private boolean read = false;
+
+    public void read() {
+        this.read = true;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/NotificationMessage.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/NotificationMessage.java
@@ -1,0 +1,22 @@
+package com.samsamhajo.deepground.notification.entity;
+
+import com.samsamhajo.deepground.notification.entity.data.NotificationData;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+@Document(collection = "notification_messages")
+public class NotificationMessage {
+
+    @Id
+    @Field("notification_message_id")
+    private String id;
+
+    @Field("notification_type")
+    private NotificationType type;
+
+    @Field("notification_data")
+    private NotificationData data;
+}

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/NotificationType.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/NotificationType.java
@@ -1,0 +1,12 @@
+package com.samsamhajo.deepground.notification.entity;
+
+public enum NotificationType {
+    FRIEND_REQUEST,         // 친구 요청
+    STUDY_GROUP_INVITE,     // 스터디 그룹 초대
+    STUDY_GROUP_JOINED,     // 스터디 그룹 가입
+    SCHEDULE_CREATED,       // 스터디 일정 생성
+    SCHEDULE_REMINDER,      // 스터디 일정 알림
+    CHAT_MESSAGE,           // 새 메시지
+
+    // TODO: QNA, FEED 알림
+}

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/data/ChatMessageNotificationData.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/data/ChatMessageNotificationData.java
@@ -1,0 +1,14 @@
+package com.samsamhajo.deepground.notification.entity.data;
+
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+public class ChatMessageNotificationData extends NotificationData {
+
+    @Field("sender_id")
+    private Long senderId;
+
+    @Field("sender")
+    private String sender;
+}

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/data/FriendRequestNotificationData.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/data/FriendRequestNotificationData.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Getter
-public abstract class NotificationData {
+public class FriendRequestNotificationData extends NotificationData {
 
-    @Field("id")
-    private Long id;
+    @Field("nickname")
+    private String nickname;
 }

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/data/NotificationData.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/data/NotificationData.java
@@ -1,0 +1,4 @@
+package com.samsamhajo.deepground.notification.entity.data;
+
+public interface NotificationData {
+}

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/data/StudyGroupNotificationData.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/data/StudyGroupNotificationData.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Getter
-public abstract class NotificationData {
+public class StudyGroupNotificationData extends NotificationData {
 
-    @Field("id")
-    private Long id;
+    @Field("title")
+    private String title;
 }

--- a/src/main/java/com/samsamhajo/deepground/notification/entity/data/StudyScheduleNotificationData.java
+++ b/src/main/java/com/samsamhajo/deepground/notification/entity/data/StudyScheduleNotificationData.java
@@ -1,0 +1,15 @@
+package com.samsamhajo.deepground.notification.entity.data;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+public class StudyScheduleNotificationData extends NotificationData {
+
+    @Field("schedule_title")
+    private String title;
+
+    @Field("start_time")
+    private LocalDateTime startTime;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,7 @@ spring:
       database: ${MONGO_DATABASE}
       username: ${MONGO_USERNAME}
       password: ${MONGO_PASSWORD}
+      auto-index-creation: true
 
 # CORS 설정
 cors:


### PR DESCRIPTION
## 📌 개요

* 알림을 저장할 수 있는 `Notification` 엔티티와 관련 클래스를 생성했습니다.

## 🛠️ 작업 내용
- MongoDB 자동 인덱스 생성 활성화
  - `Notification`에서 `@CompoundIndex`를 사용하기 위해 추가했습니다.

- `Notification` 엔티티 클래스 생성

- `NotificationMessage` 엔티티 클래스 생성

- `NotificationType` enum 클래스 생성
  - FRIEND_REQUEST(친구 요청)
  - STUDY_GROUP_INVITE(스터디 그룹 초대)
  - STUDY_GROUP_JOINED(스터디 그룹 가입)
  - SCHEDULE_CREATED(스터디 일정 생성)
  - SCHEDULE_REMINDER(스터디 일정 알림)
  - CHAT_MESSAGE(새 메시지)
  
- `NotificationData` 추상 클래스 및 구현체 생성
  - FriendRequestNotificationData(친구 요청을 받았을 때)
  - StudyGroupNotificationData(스터디 그룹 가입 수락 / 초대받았을 때)
  - StudyScheduleNotificationData(일정이 생성되었을 때 / 일정 알림이 필요할 때)
  - ChatMessageNotificationData(새 메시지를 받았을 때)
  
- `BaseDocument`에서 사용하지 않는 공통 필드 제거
  - 지금은 Document를 저장할 때 softDelete가 필요하지 않다고 생각해 제거했습니다.
  - 나중에 알림이나 채팅을 삭제하는 기능이 필요할 때 deleted를 추가하는 것이 좋을 것 같습니다.
  
- 관련 이슈 번호 #35

### Notification 엔티티 구조

* notification_id: 알림 고유 Id
* receiver_id: 알림 받는 사람 멤버 Id
* notification_message_id: 알림 메시지 Id
* read: 알림 읽음 여부
* receiver_id를 오름차순으로, created_at을 내림차순으로 정렬하는 복합 인덱스 사용

### NotificationMessage 엔티티 구조

* notification_message_id: 알림 메시지 고유 Id
* notification_type: 알림 메시지 타입
* notification_data: 알림 메시지 내용

## 📌 차후 계획 (Optional)

* Q&A, Feed 알림에 대한 구현체 생성

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 없음
- 코드 스타일 및 컨벤션 준수 확인

### 📌 기타 참고 사항

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- `NotificationType`에 추가해야 할 알림이 더 있는지 확인해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #35 