### PR TITLE
[Feature] 채팅 메시지 엔티티 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/chat/entity/ChatMessage.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/entity/ChatMessage.java
@@ -1,0 +1,31 @@
+package com.samsamhajo.deepground.chat.entity;
+
+import com.samsamhajo.deepground.global.BaseDocument;
+import jakarta.persistence.Id;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+@Document(collection = "chat_messages")
+@CompoundIndex(def = "{'chat_room_id': 1, 'created_at': -1}")
+public class ChatMessage extends BaseDocument {
+
+    @Id
+    @Field("chat_message_id")
+    private String id;
+
+    @Field("chat_room_id")
+    private Long chatRoomId;
+
+    @Field("sender_id")
+    private Long senderId;
+
+    @Field("message")
+    private String message;
+
+    @Field("media")
+    private List<ChatMessageMedia> media;
+}

--- a/src/main/java/com/samsamhajo/deepground/chat/entity/ChatMessageMedia.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/entity/ChatMessageMedia.java
@@ -1,0 +1,20 @@
+package com.samsamhajo.deepground.chat.entity;
+
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+public class ChatMessageMedia {
+
+    @Field("media_url")
+    private String mediaUrl;
+
+    @Field("file_name")
+    private String fileName;
+
+    @Field("file_size")
+    private Long fileSize;
+
+    @Field("extension")
+    private String extension;
+}


### PR DESCRIPTION
## 📌 개요

* 채팅 메시지를 저장할 수 있는 `ChatMessage` 엔티티를 생성했습니다.

## 🛠️ 작업 내용
- `ChatMessage` 엔티티 클래스 생성
- `ChatMessageMedia` 클래스 생성
- 관련 이슈 번호 #40

### ChatMessage 엔티티 구조

* chat_message_id: 채팅 메시지 고유 Id
* chat_room_id: 채팅방 Id
* sender_id: 메시지를 보낸 멤버 Id
* message: 메시지 내용
* media: 미디어 리스트(ChatMessageMedia)
* chat_room_id를 오름차순으로, created_at을 내림차순으로 정렬하는 복합 인덱스 사용

### ChatMessageMedia 구조

* media_url: 미디어 URL
* file_name: 파일 이름
* file_size: 파일 크기
* extension: 확장자

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 없음
- 코드 스타일 및 컨벤션 준수 확인

### 📌 기타 참고 사항

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #40 