### PR TITLE
[Refactor] StudyGroup 관련 엔티티 정적 팩토리 및 연관관계 매핑 리팩토링

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -1,7 +1,11 @@
 package com.samsamhajo.deepground.studyGroup.entity;
 
+import com.samsamhajo.deepground.chat.entity.ChatRoom;
 import com.samsamhajo.deepground.global.BaseEntity;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,13 +23,10 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "study_group_id")
     private Long id;
 
-    @Column(name = "chat_room_id", nullable = false)
-    private Long chatRoomId;
-
-    @Column(name = "title", nullable = false)
+    @Column(nullable = false)
     private String title;
 
-    @Column(name = "explanation", nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String explanation;
 
     @Enumerated(EnumType.STRING)
@@ -47,12 +48,54 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "group_member_count", nullable = false)
     private Integer groupMemberCount;
 
-    @Column(name = "founder_id", nullable = false)
-    private Long founderId;
-
     @Column(name = "is_offline", nullable = false)
     private Boolean isOffline;
 
     @Column(name = "study_location")
     private String studyLocation;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private ChatRoom chatRoom;
+
+    @OneToMany(mappedBy = "studyGroup")
+    private final List<StudyGroupMember> members = new ArrayList<>();
+
+    @OneToMany(mappedBy = "studyGroup")
+    private final List<StudyGroupComment> comments = new ArrayList<>();
+
+    private StudyGroup(
+        ChatRoom chatRoom, String title, String explanation,
+        LocalDate studyStartDate, LocalDate studyEndDate,
+        LocalDate recruitStartDate, LocalDate recruitEndDate,
+        Integer groupMemberCount, Member member, Boolean isOffline, String studyLocation
+    ) {
+        this.chatRoom = chatRoom;
+        this.title = title;
+        this.explanation = explanation;
+        this.studyStartDate = studyStartDate;
+        this.studyEndDate = studyEndDate;
+        this.recruitStartDate = recruitStartDate;
+        this.recruitEndDate = recruitEndDate;
+        this.groupMemberCount = groupMemberCount;
+        this.member = member;
+        this.isOffline = isOffline;
+        this.studyLocation = studyLocation;
+    }
+
+  public static StudyGroup of(
+        ChatRoom chatRoom, String title, String explanation,
+        LocalDate studyStartDate, LocalDate studyEndDate,
+        LocalDate recruitStartDate, LocalDate recruitEndDate,
+        Integer groupMemberCount, Member member, Boolean isOffline, String studyLocation
+    ) {
+        return new StudyGroup(
+            chatRoom, title, explanation,
+            studyStartDate, studyEndDate,
+            recruitStartDate, recruitEndDate,
+            groupMemberCount, member, isOffline, studyLocation
+        );
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupComment.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupComment.java
@@ -1,7 +1,10 @@
 package com.samsamhajo.deepground.studyGroup.entity;
 
 import com.samsamhajo.deepground.global.BaseEntity;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,12 +20,27 @@ public class StudyGroupComment extends BaseEntity {
     @Column(name = "comment_id")
     private Long id;
 
-    @Column(name = "study_group_id", nullable = false)
-    private Long studyGroupId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_group_id", nullable = false)
+    private StudyGroup studyGroup;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
-    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    @OneToMany(mappedBy = "comment")
+    private List<StudyGroupReply> replies = new ArrayList<>();
+
+    private StudyGroupComment(StudyGroup studyGroup, Member member, String content) {
+        this.studyGroup = studyGroup;
+        this.member = member;
+        this.content = content;
+    }
+
+    public static StudyGroupComment of(StudyGroup studyGroup, Member member, String content) {
+        return new StudyGroupComment(studyGroup, member, content);
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
@@ -21,6 +21,7 @@ public class StudyGroupMember extends BaseEntity {
     private Long id;
 
     @OneToMany(mappedBy = "studyGroupMember")
+    @JoinColumn(name = "member_id", nullable = false)
     private final List<Member> studyMember = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
@@ -1,7 +1,10 @@
 package com.samsamhajo.deepground.studyGroup.entity;
 
 import com.samsamhajo.deepground.global.BaseEntity;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,12 +20,29 @@ public class StudyGroupMember extends BaseEntity {
     @Column(name = "group_member_id")
     private Long id;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @OneToMany(mappedBy = "studyGroupMember")
+    private final List<Member> studyMember = new ArrayList<>();
 
-    @Column(name = "study_group_id", nullable = false)
-    private Long studyGroupId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_group_id", nullable = false)
+    private StudyGroup studyGroup;
 
     @Column(name = "is_allowed", nullable = false)
     private Boolean isAllowed = false;
+
+    private StudyGroupMember(StudyGroup studyGroup) {
+        this.studyGroup = studyGroup;
+    }
+
+    public static StudyGroupMember of(StudyGroup studyGroup) {
+        return new StudyGroupMember(studyGroup);
+    }
+
+    public void allowMember() {
+        this.isAllowed = true;
+    }
+
+    public void banMember() {
+        this.isAllowed = false;
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupReply.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupReply.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.studyGroup.entity;
 
 import com.samsamhajo.deepground.global.BaseEntity;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,12 +18,24 @@ public class StudyGroupReply extends BaseEntity {
     @Column(name = "study_group_reply_id")
     private Long id;
 
-    @Column(name = "comment_id", nullable = false)
-    private Long commentId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private StudyGroupComment comment;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="member_id", nullable = false)
+    private Member member;
 
-    @Column(name = "content", nullable = false)
+    @Column(nullable = false)
     private String content;
+
+    private StudyGroupReply(StudyGroupComment comment, Member member, String content) {
+        this.comment = comment;
+        this.member = member;
+        this.content = content;
+    }
+
+    public static StudyGroupReply of(StudyGroupComment comment, Member member, String content) {
+        return new StudyGroupReply(comment, member, content);
+    }
 }


### PR DESCRIPTION
## 📌 개요

- 기존 엔티티에서 `memberId`, `studyGroupId` 등의 단순 필드 기반 외래키를 사용하고 있었으나,  
    객체지향적으로 설계하기 위해 이를 실제 연관관계(@ManyToOne 등)로 매핑하였습니다.
- 생성자 대신 `정적 팩토리 메서드 (of)`를 통해 객체 생성을 명시적으로 하도록 구조를 개선하였습니다.

---

## 🛠️ 작업 내용

-  `StudyGroupMember`, `StudyGroupComment`, `StudyGroupReply`의 `memberId` → `Member` 객체로 변경
-  `StudyGroupComment`, `StudyGroupReply`의 `studyGroupId`, `commentId` → 연관 엔티티로 변경
-  모든 엔티티에 private 생성자 및 정적 팩토리 메서드(`of`) 추가
-  `@JoinColumn`을 이용한 연관관계 설정

### 🧱 StudyGroup

- 도메인 생성 책임을 `StudyGroup.of(...)`로 분리
- `members`, `comments` 양방향 관계 매핑 (mappedBy)

### 👥 StudyGroupMember

- `Long memberId` → `Member member`로 변경
- `of(Member, StudyGroup, Boolean)` 도입

### 💬 StudyGroupComment

- `studyGroup`, `member` 모두 객체 참조로 변경
- `of(StudyGroup, Member, String)` 형태로 생성

### 💭 StudyGroupReply

- `comment`, `member` 모두 객체 참조로 변경
- `of(StudyGroupComment, Member, String)` 제공

---

## 📌 차후 계획 (Optional)

- 댓글, 대댓글 조회 시 연관관계 자동 fetch 전략 튜닝 필요
- `Member` ↔ `StudyGroupMember`, `StudyGroupComment`, `StudyGroupReply`의 양방향 매핑 검토

---

## 📌 테스트 케이스

-  엔티티 연관관계 매핑 정상 작동 여부 확인
-  객체 생성 시 `of(...)` 메서드 사용 강제되는지 확인
-  기존 로직과 호환성 확인 (데이터 저장, 조회 테스트)
-  연관관계 순환 참조 문제 없는지 확인 (지연 로딩 적용됨)
---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.

- 연관관계 설정이 적절히 되어있는지 (`fetch`, `cascade`, `orphanRemoval`) 확인해주세요.
- 객체 생성 방식이 `of()`로 일관되어 있는지 확인해주세요.
- 매핑된 객체에 대해 `양방향 설정`이 필요한 곳이 빠지지 않았는지 검토해주세요.
- 테스트나 기존 기능에 영향이 있는 부분은 없는지 확인해주세요.

Closes #52