### PR TITLE
[Refactor] 채팅 관련 엔티티에 정적 팩토리 메서드 추가 및 연관관계 매핑

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/chat/entity/ChatMessage.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/entity/ChatMessage.java
@@ -1,9 +1,9 @@
 package com.samsamhajo.deepground.chat.entity;
 
 import com.samsamhajo.deepground.global.BaseDocument;
-import jakarta.persistence.Id;
 import java.util.List;
 import lombok.Getter;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -28,4 +28,19 @@ public class ChatMessage extends BaseDocument {
 
     @Field("media")
     private List<ChatMessageMedia> media;
+
+    private ChatMessage(Long chatRoomId, Long senderId, String message, List<ChatMessageMedia> media) {
+        this.chatRoomId = chatRoomId;
+        this.senderId = senderId;
+        this.message = message;
+        this.media = media;
+    }
+
+    public static ChatMessage of(Long chatRoomId, Long senderId, String message) {
+        return new ChatMessage(chatRoomId, senderId, message, null);
+    }
+
+    public static ChatMessage of(Long chatRoomId, Long senderId, String message, List<ChatMessageMedia> media) {
+        return new ChatMessage(chatRoomId, senderId, message, media);
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/chat/entity/ChatMessageMedia.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/entity/ChatMessageMedia.java
@@ -17,4 +17,15 @@ public class ChatMessageMedia {
 
     @Field("extension")
     private String extension;
+
+    private ChatMessageMedia(String mediaUrl, String fileName, Long fileSize, String extension) {
+        this.mediaUrl = mediaUrl;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.extension = extension;
+    }
+
+    public static ChatMessageMedia of(String mediaUrl, String fileName, Long fileSize, String extension) {
+        return new ChatMessageMedia(mediaUrl, fileName, fileSize, extension);
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/chat/entity/ChatRoom.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/entity/ChatRoom.java
@@ -27,4 +27,12 @@ public class ChatRoom extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "chat_room_type", nullable = false)
     private ChatRoomType chatRoomType;
+
+    private ChatRoom(ChatRoomType chatRoomType) {
+        this.chatRoomType = chatRoomType;
+    }
+
+    public static ChatRoom of(ChatRoomType chatRoomType) {
+        return new ChatRoom(chatRoomType);
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/entity/ChatRoomMember.java
@@ -1,11 +1,15 @@
 package com.samsamhajo.deepground.chat.entity;
 
 import com.samsamhajo.deepground.global.BaseEntity;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,11 +26,11 @@ public class ChatRoomMember extends BaseEntity {
     @Column(name = "chat_room_member_id")
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "member_id")
-//    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "chat_room_id")
-//    private ChatRoom chatRoom;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
 }

--- a/src/main/java/com/samsamhajo/deepground/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/entity/ChatRoomMember.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,4 +34,7 @@ public class ChatRoomMember extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
+
+    @Column(name = "last_read_message_time")
+    private LocalDateTime lastReadMessageTime;
 }

--- a/src/main/java/com/samsamhajo/deepground/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/entity/ChatRoomMember.java
@@ -37,4 +37,14 @@ public class ChatRoomMember extends BaseEntity {
 
     @Column(name = "last_read_message_time")
     private LocalDateTime lastReadMessageTime;
+
+    private ChatRoomMember(Member member, ChatRoom chatRoom) {
+        this.member = member;
+        this.chatRoom = chatRoom;
+        this.lastReadMessageTime = null;
+    }
+
+    public static ChatRoomMember of(Member member, ChatRoom chatRoom) {
+        return new ChatRoomMember(member, chatRoom);
+    }
 }


### PR DESCRIPTION
## 📌 개요

* 채팅 관련 엔티티에 정적 팩토리 메서드 추가 및 연관관계를 매핑했습니다.

## 🛠️ 작업 내용
- `ChatRoomMember` 엔티티 연관관계 매핑 (`Member`, `ChatRoom`)
- `ChatRoomMember`에 마지막으로 읽은 메시지 시간 필드 추가 (last_read_message_time)
- 채팅 관련 엔티티에 정적 팩토리 메서드 추가

## 📌 차후 계획 (Optional)

* 채팅 기능 구현

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 코드 스타일 및 컨벤션 준수 확인

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #54 