### PR TITLE
[Refactor] 멤버, 관심사, 기술스택 관련 엔티티 생성자 및 연관관계 매핑

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/interest/entity/Interest.java
+++ b/src/main/java/com/samsamhajo/deepground/interest/entity/Interest.java
@@ -23,8 +23,12 @@ public class Interest extends BaseEntity {
     @Column(name = "interest_category")
     private String category;
 
-    public Interest(String name, String category) {
+    private Interest(String name, String category) {
         this.name = name;
         this.category = category;
+    }
+
+    public static Interest of(String name, String category) {
+        return new Interest(name, category);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/interest/entity/Interest.java
+++ b/src/main/java/com/samsamhajo/deepground/interest/entity/Interest.java
@@ -22,4 +22,9 @@ public class Interest extends BaseEntity {
 
     @Column(name = "interest_category")
     private String category;
+
+    public Interest(String name, String category) {
+        this.name = name;
+        this.category = category;
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/interest/entity/MemberInterest.java
+++ b/src/main/java/com/samsamhajo/deepground/interest/entity/MemberInterest.java
@@ -25,4 +25,9 @@ public class MemberInterest extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "interest_id", nullable = false)
     private Interest interest;
+
+    public MemberInterest(Member member, Interest interest) {
+        this.member = member;
+        this.interest = interest;
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/interest/entity/MemberInterest.java
+++ b/src/main/java/com/samsamhajo/deepground/interest/entity/MemberInterest.java
@@ -26,8 +26,12 @@ public class MemberInterest extends BaseEntity {
     @JoinColumn(name = "interest_id", nullable = false)
     private Interest interest;
 
-    public MemberInterest(Member member, Interest interest) {
+    private MemberInterest(Member member, Interest interest) {
         this.member = member;
         this.interest = interest;
+    }
+
+    public static MemberInterest of(Member member, Interest interest) {
+        return new MemberInterest(member,interest);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
+++ b/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
@@ -47,10 +47,10 @@ public class Member extends BaseEntity {
     @Column(name = "provider_id")
     private String providerId;
 
-    @OneToMany(mappedBy = "members")
+    @OneToMany(mappedBy = "member")
     private List<MemberInterest> memberInterests = new ArrayList<>();
 
-    @OneToMany(mappedBy = "members")
+    @OneToMany(mappedBy = "member")
     private List<MemberTechStack> memberTechStacks = new ArrayList<>();
 
     //기본 생성자

--- a/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
+++ b/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
@@ -52,6 +52,24 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "members")
     private List<MemberTechStack> memberTechStacks = new ArrayList<>();
+
+    //기본 생성자
+    public Member(String email, String password, String nickname) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.provider = Provider.LOCAL;
+        this.isVerified = false;
+    }
+
+    //소셜 로그인 용 생성자
+    public Member(String email, Provider provider, String providerId, String nickname) {
+        this.email = email;
+        this.nickname = nickname;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.isVerified = true;
+    }
 }
 
 

--- a/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
+++ b/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
@@ -63,12 +63,12 @@ public class Member extends BaseEntity {
     }
 
     //일반 회원가입 정적 메소드
-    public Member createLocalMember(String email, String password, String nickname) {
+    public static Member createLocalMember(String email, String password, String nickname) {
         return new Member(email, password, nickname, Provider.LOCAL, null);
     }
 
     //소셜 로그인 용 정적 메소드
-    public Member createSocialMember(String email, String nickname, Provider provider, String providerId) {
+    public static Member createSocialMember(String email, String nickname, Provider provider, String providerId) {
         return new Member(email, null, nickname, provider, providerId);
     }
 

--- a/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
+++ b/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
@@ -53,21 +53,26 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<MemberTechStack> memberTechStacks = new ArrayList<>();
 
-    //기본 생성자
-    public Member(String email, String password, String nickname) {
+    public Member(String email, String password, String nickname, Provider provider, String providerId) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
-        this.provider = Provider.LOCAL;
-        this.isVerified = false;
-    }
-
-    //소셜 로그인 용 생성자
-    public Member(String email, Provider provider, String providerId, String nickname) {
-        this.email = email;
-        this.nickname = nickname;
         this.provider = provider;
         this.providerId = providerId;
+        this.isVerified = (provider != Provider.LOCAL);
+    }
+
+    //일반 회원가입 정적 메소드
+    public Member createLocalMember(String email, String password, String nickname) {
+        return new Member(email, password, nickname, Provider.LOCAL, null);
+    }
+
+    //소셜 로그인 용 정적 메소드
+    public Member createSocialMember(String email, String nickname, Provider provider, String providerId) {
+        return new Member(email, null, nickname, provider, providerId);
+    }
+
+    public void verify() {
         this.isVerified = true;
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
+++ b/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
@@ -53,7 +53,7 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<MemberTechStack> memberTechStacks = new ArrayList<>();
 
-    public Member(String email, String password, String nickname, Provider provider, String providerId) {
+    private Member(String email, String password, String nickname, Provider provider, String providerId) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
+++ b/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
@@ -1,10 +1,15 @@
 package com.samsamhajo.deepground.member.entity;
 
 import com.samsamhajo.deepground.global.BaseEntity;
+import com.samsamhajo.deepground.interest.entity.MemberInterest;
+import com.samsamhajo.deepground.techStack.entity.MemberTechStack;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -41,4 +46,16 @@ public class Member extends BaseEntity {
 
     @Column(name = "provider_id")
     private String providerId;
+
+    @OneToMany(mappedBy = "members")
+    private List<MemberInterest> memberInterests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "members")
+    private List<MemberTechStack> memberTechStacks = new ArrayList<>();
 }
+
+
+
+
+
+

--- a/src/main/java/com/samsamhajo/deepground/techStack/entity/MemberTechStack.java
+++ b/src/main/java/com/samsamhajo/deepground/techStack/entity/MemberTechStack.java
@@ -24,4 +24,9 @@ public class MemberTechStack {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tech_stack_id", nullable = false)
     private TechStack techStack;
+
+    public MemberTechStack(Member member, TechStack techStack) {
+        this.member = member;
+        this.techStack = techStack;
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/techStack/entity/MemberTechStack.java
+++ b/src/main/java/com/samsamhajo/deepground/techStack/entity/MemberTechStack.java
@@ -25,8 +25,12 @@ public class MemberTechStack {
     @JoinColumn(name = "tech_stack_id", nullable = false)
     private TechStack techStack;
 
-    public MemberTechStack(Member member, TechStack techStack) {
+    private MemberTechStack(Member member, TechStack techStack) {
         this.member = member;
         this.techStack = techStack;
+    }
+
+    public static MemberTechStack of(Member member, TechStack techStack) {
+        return new MemberTechStack(member, techStack);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/techStack/entity/TechStack.java
+++ b/src/main/java/com/samsamhajo/deepground/techStack/entity/TechStack.java
@@ -23,8 +23,12 @@ public class TechStack extends BaseEntity {
     @Column(name = "tech_stack_category")
     private String category;
 
-    public TechStack(String name, String category) {
+    private TechStack(String name, String category) {
         this.name = name;
         this.category = category;
+    }
+
+    public static TechStack of(String name, String category) {
+        return new TechStack(name, category);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/techStack/entity/TechStack.java
+++ b/src/main/java/com/samsamhajo/deepground/techStack/entity/TechStack.java
@@ -22,4 +22,9 @@ public class TechStack extends BaseEntity {
 
     @Column(name = "tech_stack_category")
     private String category;
+
+    public TechStack(String name, String category) {
+        this.name = name;
+        this.category = category;
+    }
 }


### PR DESCRIPTION
## 📌 개요
- 멤버, 관심사, 기술스택 관련 생성자 및 연관관계 매핑을 추가했습니다.

## 🛠️ 작업 내용
- `Member`에서 `mappedBy`를 활용하여 양방향 연관관계를 매핑 (`MemberInterest`, `MemberTechStack`)
- `Member`, `Interest`, `TechStack` 엔티티에 생성자 추가
- 관련 이슈 번호 (`#57`)

## 📌 차후 계획 (Optional)

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 코드 스타일 및 컨벤션 준수 확인


#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.