### PR TITLE
[Feature] WebSocket & Redis 기본 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.security:spring-security-messaging'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/src/main/java/com/samsamhajo/deepground/global/config/RedisConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.samsamhajo.deepground.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.json());
+
+        template.setHashKeySerializer(RedisSerializer.string());
+        template.setHashValueSerializer(RedisSerializer.json());
+
+        return template;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/global/config/WebSocketConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/WebSocketConfig.java
@@ -1,0 +1,32 @@
+package com.samsamhajo.deepground.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws");
+        // TODO: setAllowedOrigins
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic", "/queue")
+                .setTaskScheduler(taskScheduler());
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    private ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/global/config/WebSocketSecurityConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/WebSocketSecurityConfig.java
@@ -1,0 +1,29 @@
+package com.samsamhajo.deepground.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
+import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager.Builder;
+
+@Configuration
+@EnableWebSocketSecurity
+public class WebSocketSecurityConfig {
+
+    @Bean
+    public ChannelInterceptor csrfChannelInterceptor() {
+        return new ChannelInterceptor() {
+        };
+    }
+
+    @Bean
+    AuthorizationManager<Message<?>> authorizationManager(Builder authorizationManager) {
+        authorizationManager
+                .nullDestMatcher().permitAll()
+                // TODO: simpSubscribeDestMatchers
+                .anyMessage().denyAll();
+        return authorizationManager.build();
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/global/message/MessagePublisher.java
+++ b/src/main/java/com/samsamhajo/deepground/global/message/MessagePublisher.java
@@ -1,0 +1,8 @@
+package com.samsamhajo.deepground.global.message;
+
+public interface MessagePublisher {
+
+    void convertAndSend(String destination, Object payload);
+
+    void convertAndSendToUser(String user, String destination, Object payload);
+}

--- a/src/main/java/com/samsamhajo/deepground/global/message/SimpMessagePublisher.java
+++ b/src/main/java/com/samsamhajo/deepground/global/message/SimpMessagePublisher.java
@@ -1,0 +1,22 @@
+package com.samsamhajo.deepground.global.message;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SimpMessagePublisher implements MessagePublisher {
+
+    private final SimpMessageSendingOperations operations;
+
+    @Override
+    public void convertAndSend(String destination, Object payload) {
+        operations.convertAndSend("/topic" + destination, payload);
+    }
+
+    @Override
+    public void convertAndSendToUser(String user, String destination, Object payload) {
+        operations.convertAndSendToUser(user, "/queue" + destination, payload);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,10 @@ spring:
     open-in-view: false
     show-sql: true
   data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
     mongodb:
       host: ${MONGO_HOST}
       port: ${MONGO_PORT}


### PR DESCRIPTION
## 📌 개요

* WebSocket과 Redis를 사용하기 위한 설정을 추가했습니다.

## 🛠️ 작업 내용
- WebSocket 관련 의존성 추가 (`spring-boot-starter-websocket`, `spring-security-messaging`)
- WebSocket, WebSocketSecurity 설정 추가
- Redis 설정 추가
- `application.yml`에 Redis 연결 설정 추가
- `MessagePublisher` 추상 클래스 및 구현체 생성
  - Redis Pub/Sub 등 메시지 브로커가 필요할 때 유연하게 변경할 수 있도록 설계했습니다.

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 확인 (`build.gradle`에 `spring-boot-starter-websocket`, `spring-security-messaging` 추가)
- 코드 스타일 및 컨벤션 준수 확인

### 📌 기타 참고 사항
- Redis 설치가 필요합니다.
- Redis 연결을 위한 환경 변수들을 .env에 추가해야 합니다.
```env
REDIS_HOST=
REDIS_PORT=
REDIS_PASSWORD=
```

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #61 