### PR TITLE
[Feature] 스터디 그룹 생성 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.samsamhajo.deepground.chat.repository;
+
+import com.samsamhajo.deepground.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.samsamhajo.deepground.member.repository;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
@@ -1,0 +1,35 @@
+package com.samsamhajo.deepground.studyGroup.controller;
+
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.global.utils.GlobalLogger;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateResponse;
+import com.samsamhajo.deepground.studyGroup.service.StudyGroupService;
+import com.samsamhajo.deepground.studyGroup.success.StudyGroupSuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-group")
+public class StudyGroupController {
+
+  private final StudyGroupService studyGroupService;
+
+  @PostMapping
+  public ResponseEntity<SuccessResponse<StudyGroupCreateResponse>> createStudyGroup(
+      @RequestBody @Valid StudyGroupCreateRequest request,
+      @RequestAttribute("member") Member member
+  ) {
+    GlobalLogger.info("스터디 생성 요청", member.getEmail(), request.getTitle());
+
+    StudyGroupCreateResponse response = studyGroupService.createStudyGroup(request, member);
+
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.CREATE_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.CREATE_SUCCESS, response));
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateRequest.java
@@ -1,0 +1,37 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class StudyGroupCreateRequest {
+
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+
+  @NotBlank(message = "설명은 필수입니다.")
+  private String explanation;
+
+  @NotNull(message = "스터디 시작일은 필수입니다.")
+  private LocalDate studyStartDate;
+
+  @NotNull(message = "스터디 종료일은 필수입니다.")
+  private LocalDate studyEndDate;
+
+  @NotNull(message = "모집 시작일은 필수입니다.")
+  private LocalDate recruitStartDate;
+
+  @NotNull(message = "모집 종료일은 필수입니다.")
+  private LocalDate recruitEndDate;
+
+  @NotNull(message = "정원은 필수입니다.")
+  @Min(value = 1, message = "정원은 최소 1명 이상이어야 합니다.")
+  private Integer groupMemberCount;
+
+  @NotNull(message = "오프라인 여부는 필수입니다.")
+  private Boolean isOffline;
+
+  private String studyLocation; // isOffline이 true일 때만 필요
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateRequest.java
@@ -1,11 +1,18 @@
 package com.samsamhajo.deepground.studyGroup.dto;
 
 import jakarta.validation.constraints.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudyGroupCreateRequest {
 
   @NotBlank(message = "제목은 필수입니다.")

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateResponse.java
@@ -1,0 +1,26 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StudyGroupCreateResponse {
+
+  private Long id;
+  private String title;
+  private String explanation;
+  private Boolean isOffline;
+  private String studyLocation;
+
+  public static StudyGroupCreateResponse from(StudyGroup group) {
+    return StudyGroupCreateResponse.builder()
+        .id(group.getId())
+        .title(group.getTitle())
+        .explanation(group.getExplanation())
+        .isOffline(group.getIsOffline())
+        .studyLocation(group.getStudyLocation())
+        .build();
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
@@ -31,12 +31,14 @@ public class StudyGroupMember extends BaseEntity {
     @Column(name = "is_allowed", nullable = false)
     private Boolean isAllowed = false;
 
-    private StudyGroupMember(StudyGroup studyGroup) {
+    private StudyGroupMember(Member member, StudyGroup studyGroup, Boolean isAllowed) {
+        this.member = member;
         this.studyGroup = studyGroup;
+        this.isAllowed = isAllowed;
     }
 
-    public static StudyGroupMember of(StudyGroup studyGroup) {
-        return new StudyGroupMember(studyGroup);
+    public static StudyGroupMember of(Member member, StudyGroup studyGroup, Boolean isAllowed) {
+        return new StudyGroupMember(member, studyGroup, isAllowed);
     }
 
     public void allowMember() {

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
@@ -1,9 +1,9 @@
 package com.samsamhajo.deepground.studyGroup.repository;
 
-import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMember, Long> {
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -1,0 +1,7 @@
+package com.samsamhajo.deepground.studyGroup.repository;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -1,0 +1,69 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.chat.entity.ChatRoom;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupService {
+
+  private final StudyGroupRepository studyGroupRepository;
+  private final StudyGroupMemberRepository studyGroupMemberRepository;
+  private final ChatRoomRepository chatRoomRepository;
+
+  @Transactional
+  public StudyGroupCreateResponse createStudyGroup(StudyGroupCreateRequest request, Member creator) {
+    validateRequest(request);
+
+    // 채팅방 생성 (추후 분리 가능)
+    ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create());
+
+    StudyGroup studyGroup = StudyGroup.of(
+        chatRoom,
+        request.getTitle(),
+        request.getExplanation(),
+        request.getStudyStartDate(),
+        request.getStudyEndDate(),
+        request.getRecruitStartDate(),
+        request.getRecruitEndDate(),
+        request.getGroupMemberCount(),
+        creator,
+        request.getIsOffline(),
+        request.getStudyLocation()
+    );
+
+    StudyGroup savedGroup = studyGroupRepository.save(studyGroup);
+
+    StudyGroupMember groupMember = StudyGroupMember.of(creator, savedGroup, true);
+    studyGroupMemberRepository.save(groupMember);
+
+    return StudyGroupCreateResponse.from(savedGroup);
+  }
+
+  private void validateRequest(StudyGroupCreateRequest request) {
+    LocalDate now = LocalDate.now();
+
+    if (request.getRecruitEndDate().isBefore(now)) {
+      throw new IllegalArgumentException("모집 마감일은 현재 시점보다 미래여야 합니다.");
+    }
+
+    if (request.getStudyStartDate().isAfter(request.getStudyEndDate())) {
+      throw new IllegalArgumentException("스터디 시작일은 종료일보다 이전이어야 합니다.");
+    }
+
+    if (request.getGroupMemberCount() <= 0) {
+      throw new IllegalArgumentException("정원은 1명 이상이어야 합니다.");
+    }
+
+    // 필요한 경우 추가 유효성 체크 가능
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -1,11 +1,14 @@
 package com.samsamhajo.deepground.studyGroup.service;
 
 import com.samsamhajo.deepground.chat.entity.ChatRoom;
+import com.samsamhajo.deepground.chat.entity.ChatRoomType;
+import com.samsamhajo.deepground.chat.repository.ChatRoomRepository;
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateRequest;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateResponse;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
@@ -24,8 +27,7 @@ public class StudyGroupService {
   public StudyGroupCreateResponse createStudyGroup(StudyGroupCreateRequest request, Member creator) {
     validateRequest(request);
 
-    // 채팅방 생성 (추후 분리 가능)
-    ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create());
+    ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.of(ChatRoomType.STUDY_GROUP));
 
     StudyGroup studyGroup = StudyGroup.of(
         chatRoom,

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/success/StudyGroupSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/success/StudyGroupSuccessCode.java
@@ -1,0 +1,26 @@
+package com.samsamhajo.deepground.studyGroup.success;
+
+import com.samsamhajo.deepground.global.success.SuccessCode;
+import org.springframework.http.HttpStatus;
+
+public enum StudyGroupSuccessCode implements SuccessCode {
+  CREATE_SUCCESS(HttpStatus.CREATED, "스터디 그룹이 성공적으로 생성되었습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  StudyGroupSuccessCode(HttpStatus status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceIntegrationTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.chat.entity.ChatRoomType;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.entity.Provider;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Transactional
+class StudyGroupServiceIntegrationTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupService studyGroupService;
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private StudyGroupMemberRepository studyGroupMemberRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  private Member creator;
+
+  @BeforeEach
+  void setUp() {
+    creator = Member.createLocalMember("test@example.com", "securePassword", "테스트유저");
+    memberRepository.save(creator);
+  }
+
+  @Test
+  void createStudyGroup_successfully() {
+    // given
+    StudyGroupCreateRequest request = StudyGroupCreateRequest.builder()
+        .title("모각코 스터디")
+        .explanation("매일 오전 9시 모여서 코딩하는 스터디입니다.")
+        .studyStartDate(LocalDate.now().plusDays(7))
+        .studyEndDate(LocalDate.now().plusDays(30))
+        .recruitStartDate(LocalDate.now())
+        .recruitEndDate(LocalDate.now().plusDays(5))
+        .groupMemberCount(5)
+        .isOffline(true)
+        .studyLocation("신촌")
+        .build();
+
+    // when
+    StudyGroupCreateResponse response = studyGroupService.createStudyGroup(request, creator);
+
+    // then
+    Optional<StudyGroup> savedGroup = studyGroupRepository.findById(response.getId());
+    assertThat(savedGroup).isPresent();
+
+    StudyGroup group = savedGroup.get();
+    assertThat(group.getTitle()).isEqualTo(request.getTitle());
+    assertThat(group.getMember().getId()).isEqualTo(creator.getId());
+
+    Optional<StudyGroupMember> membership = studyGroupMemberRepository.findAll().stream()
+        .filter(m -> m.getMember().getId().equals(creator.getId()) &&
+            m.getStudyGroup().getId().equals(group.getId()))
+        .findFirst();
+
+    assertThat(membership).isPresent();
+    assertThat(membership.get().getIsAllowed()).isTrue();
+
+    assertThat(group.getChatRoom()).isNotNull();
+    assertThat(group.getChatRoom().getChatRoomType()).isEqualTo(ChatRoomType.STUDY_GROUP);
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceTest.java
@@ -1,0 +1,117 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.chat.entity.ChatRoom;
+import com.samsamhajo.deepground.chat.entity.ChatRoomType;
+import com.samsamhajo.deepground.chat.repository.ChatRoomRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateResponse;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class StudyGroupServiceTest {
+
+  private StudyGroupRepository studyGroupRepository;
+  private StudyGroupMemberRepository studyGroupMemberRepository;
+  private ChatRoomRepository chatRoomRepository;
+  private StudyGroupService studyGroupService;
+
+  @BeforeEach
+  void setUp() {
+    studyGroupRepository = mock(StudyGroupRepository.class);
+    studyGroupMemberRepository = mock(StudyGroupMemberRepository.class);
+    chatRoomRepository = mock(ChatRoomRepository.class);
+    studyGroupService = new StudyGroupService(
+        studyGroupRepository,
+        studyGroupMemberRepository,
+        chatRoomRepository
+    );
+  }
+
+  private StudyGroupCreateRequest validRequest() {
+    LocalDate now = LocalDate.now();
+    return StudyGroupCreateRequest.builder()
+        .title("Java 스터디")
+        .explanation("자바 스터디 모임입니다.")
+        .studyStartDate(now.plusDays(10))
+        .studyEndDate(now.plusDays(30))
+        .recruitStartDate(now)
+        .recruitEndDate(now.plusDays(5))
+        .groupMemberCount(5)
+        .isOffline(true)
+        .studyLocation("강남")
+        .build();
+  }
+
+  @Test
+  void createStudyGroup_success() {
+    // given
+    Member creator = mock(Member.class);
+    StudyGroupCreateRequest request = validRequest();
+    ChatRoom chatRoom = ChatRoom.of(ChatRoomType.STUDY_GROUP);
+
+    when(chatRoomRepository.save(any())).thenReturn(chatRoom);
+    when(studyGroupRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    // when
+    StudyGroupCreateResponse response = studyGroupService.createStudyGroup(request, creator);
+
+    // then
+    assertThat(response.getTitle()).isEqualTo(request.getTitle());
+    assertThat(response.getIsOffline()).isEqualTo(true);
+
+    verify(chatRoomRepository).save(any());
+    verify(studyGroupRepository).save(any());
+    verify(studyGroupMemberRepository).save(any());
+  }
+
+  @Test
+  void createStudyGroup_recruitEndDateInPast_throwsException() {
+    // given
+    Member creator = mock(Member.class);
+    StudyGroupCreateRequest request = validRequest().toBuilder()
+        .recruitEndDate(LocalDate.now().minusDays(1))
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupService.createStudyGroup(request, creator))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("모집 마감일은 현재 시점보다 미래여야 합니다.");
+  }
+
+  @Test
+  void createStudyGroup_startDateAfterEndDate_throwsException() {
+    // given
+    Member creator = mock(Member.class);
+    StudyGroupCreateRequest request = validRequest().toBuilder()
+        .studyStartDate(LocalDate.now().plusDays(20))
+        .studyEndDate(LocalDate.now().plusDays(10))
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupService.createStudyGroup(request, creator))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("스터디 시작일은 종료일보다 이전이어야 합니다.");
+  }
+
+  @Test
+  void createStudyGroup_zeroMemberCount_throwsException() {
+    // given
+    Member creator = mock(Member.class);
+    StudyGroupCreateRequest request = validRequest().toBuilder()
+        .groupMemberCount(0)
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupService.createStudyGroup(request, creator))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("정원은 1명 이상이어야 합니다.");
+  }
+}


### PR DESCRIPTION
## 📌 개요

스터디 그룹을 생성할 수 있는 API를 구현하였습니다. 사용자가 제목, 설명, 일정, 정원 등의 정보를 입력하면 DB에 저장되며, 생성자는 자동으로 해당 스터디의 참여자로 등록됩니다.

## 🛠️ 작업 내용

-  `StudyGroupCreateRequest`, `StudyGroupCreateResponse` DTO 설계
-  스터디 생성 API 구현 (`StudyGroupController`, `StudyGroupService`)
-  유효성 검증 로직 작성
-  `StudyGroup`, `StudyGroupMember` 연관 관계 설정 및 저장 로직 작성
-  단위 및 통합 테스트 작성 (`@Mock`, `@Transactional` 기반)

### 📌 스터디 그룹 생성 API

- 사용자가 요청을 보내면 ChatRoom이 생성되고, StudyGroup과 StudyGroupMember가 함께 생성됩니다.
- `StudyGroupCreateRequest`로 요청을 받고, 성공 시 `StudyGroupCreateResponse`를 반환합니다.
    

```http
POST /study-group
Authorization: Bearer <token>
Content-Type: application/json

{
  "title": "모각코 스터디",
  "explanation": "매일 오전 9시 모여서 코딩하는 스터디입니다.",
  "studyStartDate": "2025-05-19",
  "studyEndDate": "2025-06-11",
  "recruitStartDate": "2025-05-12",
  "recruitEndDate": "2025-05-17",
  "groupMemberCount": 5,
  "isOffline": true,
  "studyLocation": "신촌"
}
```

### 📌 유효성 검증

- 모집 마감일은 오늘 이후여야 함
- 스터디 시작일은 종료일보다 먼저여야 함
- 정원은 1명 이상이어야 함
- 잘못된 요청 시 `IllegalArgumentException` 발생 후 400 응답 처리

|테스트 케이스|
|:-:|
|`스터디 정상 생성`, `마감일 과거`, `시작일 > 종료일`, `정원 0명` 등 예외 포함|

## 📌 차후 계획 (Optional)

- `스터디 수정`, `삭제`, `조회` API 구현 예정
- Swagger 문서화 적용
- 정원 제한을 서버 설정 값으로 변경할 수 있도록 개선
- 프론트 연동 시 에러 메시지 응답 포맷 표준화 검토 예정

## 📌 테스트 케이스

-  기능 정상 동작 확인 (통합 테스트 통과)
-  새로운 의존성 추가 여부 없음
-  코드 스타일 및 컨벤션 준수 확인
-  기존 테스트 모두 통과  
- `createStudyGroup_successfully()` 통합 테스트를 통해 DB 저장 확인
- 유효성 실패 케이스 각각에 대해 예외 발생 여부 검증

---

### 📌 기타 참고 사항

- 현재 인증된 사용자만 API를 호출할 수 있도록 설정되어 있으며, member는 `@RequestAttribute("member")`로 주입됩니다.
- `GlobalLogger`를 활용해 요청 로그를 출력합니다.
- `SuccessResponse` 구조를 공통 응답으로 사용하여 일관된 API 형식을 유지합니다.

closes #105 
