### PR TITLE
[Feature] 스터디 그룹 목록 검색 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.samsamhajo.deepground.member.repository;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
@@ -1,0 +1,31 @@
+package com.samsamhajo.deepground.studyGroup.controller;
+
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.global.utils.GlobalLogger;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupSearchRequest;
+import com.samsamhajo.deepground.studyGroup.service.StudyGroupService;
+import com.samsamhajo.deepground.studyGroup.success.StudyGroupSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-group")
+public class StudyGroupController {
+
+  private final StudyGroupService studyGroupService;
+
+  @GetMapping("/search")
+  public ResponseEntity<SuccessResponse<?>> searchStudyGroups(
+      @ModelAttribute StudyGroupSearchRequest request
+  ) {
+    GlobalLogger.info("스터디 목록 검색 요청", request.getKeyword(), request.getGroupStatus());
+
+    var response = studyGroupService.searchStudyGroups(request);
+
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.CREATE_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.CREATE_SUCCESS, response));
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
@@ -1,0 +1,30 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class StudyGroupResponse {
+  private Long id;
+  private String title;
+  private String explanation;
+  private GroupStatus groupStatus;
+  private LocalDate recruitEndDate;
+  private String studyLocation;
+
+  public static StudyGroupResponse from(StudyGroup group) {
+    return StudyGroupResponse.builder()
+        .id(group.getId())
+        .title(group.getTitle())
+        .explanation(group.getExplanation())
+        .groupStatus(group.getGroupStatus())
+        .recruitEndDate(group.getRecruitEndDate())
+        .studyLocation(group.getStudyLocation())
+        .build();
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupSearchRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupSearchRequest.java
@@ -1,0 +1,29 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public class StudyGroupSearchRequest {
+
+  private final String keyword;
+  private final GroupStatus groupStatus;
+  private final int page;
+  private final int size;
+
+  @Builder
+  public StudyGroupSearchRequest(String keyword, GroupStatus groupStatus, int page, int size) {
+    this.keyword = keyword;
+    this.groupStatus = groupStatus;
+    this.page = page;
+    this.size = size;
+  }
+
+  public Pageable toPageable() {
+    return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -54,7 +54,8 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "study_location")
     private String studyLocation;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -97,5 +98,9 @@ public class StudyGroup extends BaseEntity {
             recruitStartDate, recruitEndDate,
             groupMemberCount, member, isOffline, studyLocation
         );
+    }
+
+    public void changeGroupStatus(GroupStatus newStatus) {
+        this.groupStatus = newStatus;
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -1,0 +1,28 @@
+package com.samsamhajo.deepground.studyGroup.repository;
+
+import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+
+  Page<StudyGroup> findByGroupStatusAndTitleContainingIgnoreCaseOrGroupStatusAndExplanationContainingIgnoreCase(
+      GroupStatus status1, String titleKeyword,
+      GroupStatus status2, String explanationKeyword,
+      Pageable pageable
+  );
+
+  Page<StudyGroup> findByTitleContainingIgnoreCaseOrExplanationContainingIgnoreCase(
+      String titleKeyword, String explanationKeyword,
+      Pageable pageable
+  );
+
+  Page<StudyGroup> findByGroupStatus(
+      GroupStatus groupStatus,
+      Pageable pageable
+  );
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -1,0 +1,44 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupResponse;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupSearchRequest;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupService {
+
+  private final StudyGroupRepository studyGroupRepository;
+
+  public Page<StudyGroupResponse> searchStudyGroups(StudyGroupSearchRequest request) {
+    String keyword = request.getKeyword();
+    var status = request.getGroupStatus();
+    var pageable = request.toPageable();
+
+    Page<StudyGroup> pageResult;
+
+    if (keyword != null && !keyword.isBlank()) {
+      if (status != null) {
+        pageResult = studyGroupRepository
+            .findByGroupStatusAndTitleContainingIgnoreCaseOrGroupStatusAndExplanationContainingIgnoreCase(
+                status, keyword, status, keyword, pageable
+            );
+      } else {
+        pageResult = studyGroupRepository
+            .findByTitleContainingIgnoreCaseOrExplanationContainingIgnoreCase(keyword, keyword, pageable);
+      }
+    } else {
+      if (status != null) {
+        pageResult = studyGroupRepository.findByGroupStatus(status, pageable);
+      } else {
+        pageResult = studyGroupRepository.findAll(pageable);
+      }
+    }
+
+    return pageResult.map(StudyGroupResponse::from);
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/success/StudyGroupSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/success/StudyGroupSuccessCode.java
@@ -1,0 +1,26 @@
+package com.samsamhajo.deepground.studyGroup.success;
+
+import com.samsamhajo.deepground.global.success.SuccessCode;
+import org.springframework.http.HttpStatus;
+
+public enum StudyGroupSuccessCode implements SuccessCode {
+  CREATE_SUCCESS(HttpStatus.CREATED, "스터디 그룹이 성공적으로 생성되었습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  StudyGroupSuccessCode(HttpStatus status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepositoryTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.samsamhajo.deepground.studyGroup.repository;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.*;
+
+import java.time.LocalDate;
+import java.util.stream.IntStream;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Transactional
+@Rollback
+class StudyGroupRepositoryTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  private Member creator;
+
+  @BeforeEach
+  void setUp() {
+    creator = Member.createLocalMember("repo@test.com", "1234", "저장자");
+    memberRepository.save(creator);
+
+    // 15개 모집중, 5개 모집종료, 다양한 키워드 포함
+    IntStream.rangeClosed(1, 20).forEach(i -> {
+      GroupStatus status = i <= 15 ? GroupStatus.RECRUITING : GroupStatus.COMPLETED;
+      String title = i % 2 == 0 ? "자바 스터디" : "파이썬 스터디";
+      String explanation = i % 3 == 0 ? "알고리즘 풀이" : "웹 개발";
+
+      StudyGroup group = StudyGroup.of(
+          null,
+          title,
+          explanation,
+          LocalDate.now().plusDays(1),
+          LocalDate.now().plusDays(30),
+          LocalDate.now(),
+          LocalDate.now().plusDays(5),
+          5,
+          creator,
+          true,
+          "강남"
+      );
+      group.changeGroupStatus(status);
+      studyGroupRepository.save(group);
+    });
+  }
+
+  @Test
+  void findByGroupStatusAndTitleOrExplanation() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<StudyGroup> result = studyGroupRepository
+        .findByGroupStatusAndTitleContainingIgnoreCaseOrGroupStatusAndExplanationContainingIgnoreCase(
+            GroupStatus.RECRUITING, "자바",
+            GroupStatus.RECRUITING, "자바",
+            pageable
+        );
+
+    assertThat(result.getTotalElements()).isGreaterThan(0);
+    assertThat(result.getContent()).allMatch(group ->
+        group.getGroupStatus() == GroupStatus.RECRUITING &&
+            (group.getTitle().contains("자바") || group.getExplanation().contains("자바"))
+    );
+  }
+
+  @Test
+  void findByTitleOrExplanation() {
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<StudyGroup> result = studyGroupRepository
+        .findByTitleContainingIgnoreCaseOrExplanationContainingIgnoreCase("파이썬", "파이썬", pageable);
+
+    assertThat(result.getTotalElements()).isGreaterThan(0);
+    assertThat(result.getContent()).allMatch(group ->
+        group.getTitle().contains("파이썬") || group.getExplanation().contains("파이썬")
+    );
+  }
+
+  @Test
+  void findByGroupStatus_onlyRecruiting() {
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<StudyGroup> result = studyGroupRepository.findByGroupStatus(GroupStatus.RECRUITING, pageable);
+
+    assertThat(result.getTotalElements()).isEqualTo(15);
+    assertThat(result.getContent()).allMatch(group -> group.getGroupStatus() == GroupStatus.RECRUITING);
+  }
+
+  @Test
+  void findAll_pagingWorks() {
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<StudyGroup> page = studyGroupRepository.findAll(pageable);
+
+    assertThat(page.getTotalElements()).isEqualTo(20);
+    assertThat(page.getContent().size()).isEqualTo(10);
+    assertThat(page.getTotalPages()).isEqualTo(2);
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceSearchTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceSearchTest.java
@@ -1,0 +1,127 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupResponse;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupSearchRequest;
+import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.util.stream.IntStream;
+import org.springframework.test.annotation.Rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@Rollback
+class StudyGroupServiceSearchTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private StudyGroupService studyGroupService;
+
+  private Member creator;
+
+  @BeforeEach
+  void setUp() {
+    creator = Member.createLocalMember("test@test.com", "pw", "테스터");
+    memberRepository.save(creator);
+
+    IntStream.rangeClosed(1, 20).forEach(i -> {
+      String title = (i % 2 == 0) ? "자바 스터디" : "파이썬 스터디";
+      String explanation = (i % 3 == 0) ? "알고리즘 풀이" : "웹 개발";
+      GroupStatus status = (i <= 15) ? GroupStatus.RECRUITING : GroupStatus.COMPLETED;
+
+      StudyGroup group = StudyGroup.of(
+          null, title, explanation,
+          LocalDate.now().plusDays(1),
+          LocalDate.now().plusDays(30),
+          LocalDate.now(),
+          LocalDate.now().plusDays(5),
+          5, creator, true, "강남"
+      );
+      group.changeGroupStatus(status);
+      studyGroupRepository.save(group);
+    });
+  }
+
+  @Test
+  @DisplayName("키워드와 모집 상태를 기반으로 스터디 목록을 검색할 수 있다")
+  void searchByKeywordAndStatus() {
+    StudyGroupSearchRequest request = StudyGroupSearchRequest.builder()
+        .keyword("자바")
+        .groupStatus(GroupStatus.RECRUITING)
+        .page(0)
+        .size(10)
+        .build();
+
+    Page<StudyGroupResponse> result = studyGroupService.searchStudyGroups(request);
+
+    assertThat(result.getTotalElements()).isGreaterThan(0);
+    assertThat(result.getContent())
+        .allSatisfy(res -> {
+          assertThat(res.getGroupStatus()).isEqualTo(GroupStatus.RECRUITING);
+          assertThat(res.getTitle()).contains("자바");
+        });
+  }
+
+  @Test
+  @DisplayName("키워드만으로 스터디 목록을 검색할 수 있다")
+  void searchByKeywordOnly() {
+    StudyGroupSearchRequest request = StudyGroupSearchRequest.builder()
+        .keyword("파이썬")
+        .page(0)
+        .size(10)
+        .build();
+
+    Page<StudyGroupResponse> result = studyGroupService.searchStudyGroups(request);
+
+    assertThat(result.getTotalElements()).isGreaterThan(0);
+    assertThat(result.getContent())
+        .allSatisfy(res -> assertThat(res.getTitle()).contains("파이썬"));
+  }
+
+  @Test
+  @DisplayName("모집 상태만으로 스터디 목록을 검색할 수 있다")
+  void searchByStatusOnly() {
+    StudyGroupSearchRequest request = StudyGroupSearchRequest.builder()
+        .groupStatus(GroupStatus.RECRUITING)
+        .page(0)
+        .size(10)
+        .build();
+
+    Page<StudyGroupResponse> result = studyGroupService.searchStudyGroups(request);
+
+    assertThat(result.getTotalElements()).isEqualTo(15);
+    assertThat(result.getContent())
+        .allSatisfy(res -> assertThat(res.getGroupStatus()).isEqualTo(GroupStatus.RECRUITING));
+  }
+
+  @Test
+  @DisplayName("필터 없이 전체 목록을 페이징 처리하여 가져올 수 있다")
+  void searchWithoutFilter() {
+    StudyGroupSearchRequest request = StudyGroupSearchRequest.builder()
+        .page(0)
+        .size(10)
+        .build();
+
+    Page<StudyGroupResponse> result = studyGroupService.searchStudyGroups(request);
+
+    assertThat(result.getTotalElements()).isEqualTo(20);
+    assertThat(result.getContent()).hasSize(10);
+  }
+}


### PR DESCRIPTION
## 📌 개요
스터디 그룹 목록을 키워드, 모집 상태 등의 조건으로 검색하고, 페이지 단위로 정렬된 결과를 반환하는 기능을 구현했습니다.
---

## 🛠️ 작업 내용

-  검색 조건(`keyword`, `groupStatus`, `page`, `size`)을 담는 `StudyGroupSearchRequest` DTO 작성
-  `StudyGroupRepository`에 검색 조건에 따른 쿼리 메서드 추가
-  조건 분기에 따라 검색을 수행하는 `StudyGroupService` 구현
-  검색 API를 처리하는 `StudyGroupController`의 `/search` 엔드포인트 추가
-  검색 기능에 대한 통합 테스트(`StudyGroupServiceTest`) 작성 및 검증
-  요청 파라미터 바인딩을 위한 `@ModelAttribute` 기반 DTO 수정

### 🔍 검색 조건 분기 처리

- 키워드 + 모집 상태 둘 다 있을 경우  
    → `findByGroupStatusAndTitleContainingIgnoreCaseOrGroupStatusAndExplanationContainingIgnoreCase`
- 키워드만 있을 경우  
    → `findByTitleContainingIgnoreCaseOrExplanationContainingIgnoreCase`
- 모집 상태만 있을 경우  
    → `findByGroupStatus`
- 둘 다 없을 경우  
    → `findAll`

---

## 📌 차후 계획 (Optional)

- 정렬 옵션 추가 (예: 인기순, 마감임박순 등)    
- 지역/오프라인 여부 필터 추가
- MySQL 인덱스 추가 튜닝 및 검색 쿼리 JPQL 커스터마이징

---

## 📌 테스트 케이스

-  키워드 + 모집 상태로 검색 시 정상 작동 여부 확인
-  키워드만 입력 시 검색 가능 여부 확인
-  모집 상태만 입력 시 정상 검색 확인
-  조건 없이 전체 검색 및 페이지네이션 동작 여부 확인
-  통합 테스트 코드(`StudyGroupServiceSearchTest`) 작성 및 통과 확인

---

## 📌 기타 참고 사항

- 기존에 사용 중인 엔티티 `StudyGroup`, `Member` 등을 그대로 활용하면서 검색 조건 분기만 명확히 나눠서 처리하였습니다.
- 키워드 검색 조건은 `title`, `explanation` 컬럼 양쪽을 모두 고려하여 OR 조건으로 설정했습니다.
- `page`, `size` 기본값은 0, 10으로 고정되어 있으며, 추후 클라이언트 요구에 따라 조정 가능합니다.

---

### 🙏🏻아래와 같이 PR을 리뷰해주세요.

- 컨트롤러 → 서비스 → 레포지토리 흐름이 명확한지
- 쿼리 메서드 네이밍 및 조건 분기가 직관적인지
- 테스트가 실제 동작 케이스를 모두 커버하는지

Closes #106 