### PR TITLE
[Feature] 스터디 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.samsamhajo.deepground.member.repository;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
@@ -1,0 +1,30 @@
+package com.samsamhajo.deepground.studyGroup.controller;
+
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.global.utils.GlobalLogger;
+import com.samsamhajo.deepground.studyGroup.service.StudyGroupService;
+import com.samsamhajo.deepground.studyGroup.success.StudyGroupSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-group")
+public class StudyGroupController {
+
+  private final StudyGroupService studyGroupService;
+
+  @GetMapping("/{studyGroupId}")
+  public ResponseEntity<SuccessResponse<?>> getStudyGroupDetail(
+      @PathVariable Long studyGroupId
+  ) {
+    GlobalLogger.info("스터디 그룹 상세 조회 요청", studyGroupId);
+
+    var response = studyGroupService.getStudyGroupDetail(studyGroupId);
+
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.READ_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.READ_SUCCESS, response));
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
@@ -1,0 +1,44 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class StudyGroupDetailResponse {
+  private Long id;
+  private String title;
+  private String explanation;
+  private String writer;
+  private int memberCount;
+  private int groupLimit;
+  private String location;
+  private boolean isOffline;
+  private String recruitEndDate;
+  private int commentCount;
+  private List<String> participants;
+
+  public static StudyGroupDetailResponse from(StudyGroup group) {
+    return StudyGroupDetailResponse.builder()
+        .id(group.getId())
+        .title(group.getTitle())
+        .explanation(group.getExplanation())
+        .writer(group.getMember().getNickname())
+        .memberCount(group.getMembers().size())
+        .groupLimit(group.getGroupMemberCount())
+        .location(group.getStudyLocation())
+        .isOffline(group.getIsOffline())
+        .recruitEndDate(group.getRecruitEndDate().toString())
+        .commentCount(group.getComments().size())
+        .participants(
+            group.getMembers().stream()
+                .map(m -> m.getMember().getNickname())
+                .collect(Collectors.toList())
+        )
+        .build();
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -5,7 +5,9 @@ import com.samsamhajo.deepground.global.BaseEntity;
 import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.persistence.*;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,14 +56,16 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "study_location")
     private String studyLocation;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
 
     @OneToOne(fetch = FetchType.LAZY)
     private ChatRoom chatRoom;
 
     @OneToMany(mappedBy = "studyGroup")
-    private final List<StudyGroupMember> members = new ArrayList<>();
+    private final Set<StudyGroupMember> members = new HashSet<>();
 
     @OneToMany(mappedBy = "studyGroup")
     private final List<StudyGroupComment> comments = new ArrayList<>();

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMember.java
@@ -31,12 +31,14 @@ public class StudyGroupMember extends BaseEntity {
     @Column(name = "is_allowed", nullable = false)
     private Boolean isAllowed = false;
 
-    private StudyGroupMember(StudyGroup studyGroup) {
+    private StudyGroupMember(Member member, StudyGroup studyGroup, Boolean isAllowed) {
+        this.member = member;
         this.studyGroup = studyGroup;
+        this.isAllowed = isAllowed;
     }
 
-    public static StudyGroupMember of(StudyGroup studyGroup) {
-        return new StudyGroupMember(studyGroup);
+    public static StudyGroupMember of(Member member, StudyGroup studyGroup, Boolean isAllowed) {
+        return new StudyGroupMember(member, studyGroup, isAllowed);
     }
 
     public void allowMember() {

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/exception/StudyGroupNotFoundException.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/exception/StudyGroupNotFoundException.java
@@ -1,0 +1,7 @@
+package com.samsamhajo.deepground.studyGroup.exception;
+
+public class StudyGroupNotFoundException extends RuntimeException {
+  public StudyGroupNotFoundException(Long id) {
+    super("해당 ID의 스터디 그룹을 찾을 수 없습니다: " + id);
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -1,0 +1,18 @@
+package com.samsamhajo.deepground.studyGroup.repository;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
+
+  @Query("SELECT sg FROM StudyGroup sg " +
+      "LEFT JOIN FETCH sg.member " +
+      "LEFT JOIN FETCH sg.members " +
+      "LEFT JOIN FETCH sg.comments " +
+      "WHERE sg.id = :id")
+  Optional<StudyGroup> findWithMemberAndCommentsById(@Param("id") Long studyGroupId);
+
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -1,0 +1,22 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupDetailResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupService {
+
+  private final StudyGroupRepository studyGroupRepository;
+
+  public StudyGroupDetailResponse getStudyGroupDetail(Long studyGroupId) {
+    StudyGroup group = studyGroupRepository.findWithMemberAndCommentsById(studyGroupId)
+        .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
+
+    return StudyGroupDetailResponse.from(group);
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/success/StudyGroupSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/success/StudyGroupSuccessCode.java
@@ -1,0 +1,27 @@
+package com.samsamhajo.deepground.studyGroup.success;
+
+import com.samsamhajo.deepground.global.success.SuccessCode;
+import org.springframework.http.HttpStatus;
+
+public enum StudyGroupSuccessCode implements SuccessCode {
+  CREATE_SUCCESS(HttpStatus.CREATED, "스터디 그룹이 성공적으로 생성되었습니다."),
+  READ_SUCCESS(HttpStatus.OK, "스터디 그룹 상세 조회 성공");
+
+  private final HttpStatus status;
+  private final String message;
+
+  StudyGroupSuccessCode(HttpStatus status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepositoryTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.samsamhajo.deepground.studyGroup.repository;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class StudyGroupRepositoryTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @PersistenceContext
+  private EntityManager em;
+
+  private StudyGroup savedGroup;
+
+  @BeforeEach
+  void setUp() {
+    Member writer = Member.createLocalMember("writer@test.com", "1234", "작성자");
+    Member participant = Member.createLocalMember("user@test.com", "1234", "참여자");
+    memberRepository.save(writer);
+    memberRepository.save(participant);
+
+    StudyGroup group = StudyGroup.of(
+        null, "테스트 스터디", "설명입니다",
+        LocalDate.now().plusDays(1),
+        LocalDate.now().plusDays(10),
+        LocalDate.now(),
+        LocalDate.now().plusDays(5),
+        10,
+        writer,
+        true,
+        "강남"
+    );
+    savedGroup = studyGroupRepository.save(group);
+    em.flush();
+    em.clear();
+
+    StudyGroupMember groupMember = StudyGroupMember.of(participant, savedGroup, true);
+    StudyGroupComment comment = StudyGroupComment.of(savedGroup, participant, "댓글입니다");
+
+    em.persist(groupMember);
+    em.persist(comment);
+
+    em.flush();
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("스터디 그룹 ID로 상세 조회 시 작성자, 멤버 목록, 댓글 목록이 함께 조회된다")
+  void findWithMemberAndCommentsById() {
+    Optional<StudyGroup> result = studyGroupRepository.findWithMemberAndCommentsById(savedGroup.getId());
+
+    assertThat(result).isPresent();
+    StudyGroup group = result.get();
+
+    assertThat(group.getTitle()).isEqualTo("테스트 스터디");
+    assertThat(group.getMember()).isNotNull(); // 작성자
+    assertThat(group.getMembers()).hasSize(1); // 그룹 멤버 1명
+    assertThat(group.getComments()).hasSize(1); // 댓글 1개
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceDetailsTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceDetailsTest.java
@@ -1,0 +1,94 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupDetailResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+class StudyGroupServiceDetailsTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupService studyGroupService;
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @PersistenceContext
+  private EntityManager em;
+
+  private Long studyGroupId;
+
+  @BeforeEach
+  void setUp() {
+    Member writer = Member.createLocalMember("writer@test.com", "1234", "작성자");
+    Member participant = Member.createLocalMember("user@test.com", "1234", "참여자");
+    memberRepository.save(writer);
+    memberRepository.save(participant);
+
+    StudyGroup group = StudyGroup.of(
+        null, "통합테스트 스터디", "설명입니다",
+        LocalDate.now().plusDays(1),
+        LocalDate.now().plusDays(10),
+        LocalDate.now(),
+        LocalDate.now().plusDays(5),
+        10,
+        writer,
+        true,
+        "강남"
+    );
+    studyGroupRepository.save(group);
+
+    StudyGroupMember groupMember = StudyGroupMember.of(participant, group, true);
+    StudyGroupComment comment = StudyGroupComment.of(group, participant, "댓글입니다");
+
+    em.persist(groupMember);
+    em.persist(comment);
+    em.flush();
+    em.clear();
+
+    studyGroupId = group.getId();
+  }
+
+  @Test
+  @DisplayName("스터디 그룹 ID로 상세 조회하면 작성자, 멤버, 댓글이 모두 포함된다")
+  void getStudyGroupDetail_success() {
+    // when
+    StudyGroupDetailResponse result = studyGroupService.getStudyGroupDetail(studyGroupId);
+
+    // then
+    assertThat(result.getTitle()).isEqualTo("통합테스트 스터디");
+    assertThat(result.getWriter()).isEqualTo("작성자");
+    assertThat(result.getParticipants()).contains("참여자");
+    // TODO: 댓글 도메인 구현 시, 관련 DTO 수정 필요함
+//    assertThat(result.get).contains("댓글입니다");
+  }
+
+  @Test
+  @DisplayName("스터디 그룹 ID가 존재하지 않으면 예외가 발생한다")
+  void getStudyGroupDetail_notFound() {
+    // when & then
+    assertThatThrownBy(() -> studyGroupService.getStudyGroupDetail(-1L))
+        .isInstanceOf(StudyGroupNotFoundException.class);
+  }
+}


### PR DESCRIPTION
## 📌 개요

스터디 그룹 상세 정보를 조회할 수 있는 API를 구현했습니다. 작성자, 참여자 목록, 댓글 목록을 함께 조회하도록 쿼리를 최적화하고 DTO에 반영했습니다.

## 🛠️ 작업 내용

-  스터디 그룹 상세 조회용 Repository 쿼리 작성 (`findWithMemberAndCommentsById`)
-  서비스 로직 구현 (`getStudyGroupDetail`)
-  DTO(`StudyGroupDetailResponse`)에 참여자 목록 및 댓글 목록 필드 추가
-  Controller에 상세 조회 API 추가 (`GET /study-group/{studyGroupId}`)
-  통합 테스트 및 서비스 테스트 작성

### 🔍 스터디 그룹 상세 조회 쿼리 작성 및 예외 처리

- `@Query`를 통해 작성자, 멤버, 댓글을 한 번에 Fetch Join
- 존재하지 않는 경우 `StudyGroupNotFoundException` 반환

### 🧾 응답 DTO 개선

- 기존 필드 외에 참여자 목록 (`List<String> participants`) 추가
- 댓글 목록 (`List<String> comments`) 추가

### 🧪 테스트 코드 작성

- 통합 테스트(`IntegrationTestSupport` 상속) 기반으로 Service 단 검증
- Mock 데이터: 작성자 + 참여자 + 댓글 생성 후 검증

## 📌 차후 계획 (Optional)

- 댓글의 구조 고도화 (작성자, 시간 포함 등)
- 참여자 수 기준으로 모집 상태 판단 기능 추가 예정
- `@EntityGraph` 도입 검토로 Fetch Join 복잡도 개선

## 📌 테스트 케이스

-  기능 정상 동작 확인 (`스터디 제목`, `참여자 수`, `댓글 수` 검증)
-  새로운 의존성 추가 없음
-  코드 스타일 및 컨벤션 준수
-  기존 테스트 전부 통과

## 📌 기타 참고 사항

- `MultipleBagFetchException` 이슈 발생으로 `Set` 구조로 컬렉션 변경

Closes #107 