### PR TITLE
[Feature] 친구 요청 목록 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/friend/Dto/FriendDto.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Dto/FriendDto.java
@@ -1,0 +1,24 @@
+package com.samsamhajo.deepground.friend.Dto;
+
+import com.samsamhajo.deepground.friend.entity.Friend;
+import com.samsamhajo.deepground.friend.entity.FriendStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FriendDto {
+
+    private Long friendId;
+    private String otherMemberName;
+    private FriendStatus status;
+
+    public static FriendDto fromSent(Friend friend) {
+        return new FriendDto(
+                friend.getId(),
+                friend.getReceiveMember().getNickname(),
+                friend.getStatus()
+        );
+    }
+
+}

--- a/src/main/java/com/samsamhajo/deepground/friend/Dto/ResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Dto/ResponseDto.java
@@ -1,0 +1,19 @@
+package com.samsamhajo.deepground.friend.Dto;
+
+
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+public class ResponseDto {
+
+    private int status;
+    private String message;
+    private Object data;
+
+    public ResponseDto(HttpStatus status, String message, Object data) {
+        this.status = status.value();
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.friend.controller;
 
+import com.samsamhajo.deepground.friend.Dto.FriendRequestDto;
 import com.samsamhajo.deepground.friend.Dto.ResponseDto;
 import com.samsamhajo.deepground.friend.service.FriendService;
 import com.samsamhajo.deepground.member.entity.Member;
@@ -28,11 +29,6 @@ public class FriendController {
     }
 
 
-    @Data
-    static class FriendRequestDto {
-        private Long requesterId;
-        private String receiverEmail;
-    }
 
     @Data
     @AllArgsConstructor

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.friend.controller;
 
+import com.samsamhajo.deepground.friend.Dto.FriendDto;
 import com.samsamhajo.deepground.friend.Dto.FriendRequestDto;
 import com.samsamhajo.deepground.friend.Dto.ResponseDto;
 import com.samsamhajo.deepground.friend.service.FriendService;
@@ -10,30 +11,32 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
-
-@RestController
+@RestController("/api/v1/friends")
 @RequiredArgsConstructor
 public class FriendController {
 
     private final FriendService friendService;
 
-    @PostMapping("/api/v1/friends/request")
+    @PostMapping("/request")
     public ResponseEntity<ResponseDto> requestFriend(@RequestBody @Valid FriendRequestDto dto) {
         Long friendId = friendService.sendFriendRequest(dto.getRequesterId(), dto.getReceiverEmail());
         return ResponseEntity.ok().body(new ResponseDto(HttpStatus.OK, "친구 요청을 보냈습니다!", new SendFriendResponse(friendId)));
     }
 
-
-
     @Data
     @AllArgsConstructor
     static class SendFriendResponse {
         private Long id;
+    }
+
+    @GetMapping("/sent")
+    public ResponseEntity<List<FriendDto>> getSentFriendRequests(@RequestParam Long requesterId) {
+        return ResponseEntity.ok(friendService.findSentFriendRequest(requesterId));
     }
 
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -1,18 +1,19 @@
 package com.samsamhajo.deepground.friend.controller;
 
+import com.samsamhajo.deepground.friend.Dto.ResponseDto;
 import com.samsamhajo.deepground.friend.service.FriendService;
 import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -21,24 +22,26 @@ public class FriendController {
     private final FriendService friendService;
 
     @PostMapping("/api/v1/friends/request")
-    public SendFriendResponse requestFriend(@RequestBody @Valid FriendRequestDto dto) {
-        Long friendId = friendService.sendFriendRequest(dto.getRequesterId(),dto.getReceiverEmail());
-        return new SendFriendResponse(friendId);
+    public ResponseEntity<ResponseDto> requestFriend(@RequestBody @Valid FriendRequestDto dto) {
+        Long friendId = friendService.sendFriendRequest(dto.getRequesterId(), dto.getReceiverEmail());
+        return ResponseEntity.ok().body(new ResponseDto(HttpStatus.OK, "친구 요청을 보냈습니다!", new SendFriendResponse(friendId)));
     }
 
 
     @Data
     static class FriendRequestDto {
-    private Long requesterId;
-    private String receiverEmail;
+        private Long requesterId;
+        private String receiverEmail;
     }
 
     @Data
     @AllArgsConstructor
-    static class SendFriendResponse  {
+    static class SendFriendResponse {
         private Long id;
     }
 
-
-
 }
+
+
+
+

--- a/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
@@ -14,4 +14,5 @@ public interface FriendRepository extends JpaRepository<Friend,Long> {
 
     boolean existsByRequestMemberAndReceiveMember(Member requester, Member receiver);
 
+    boolean existsByRequestMemberAndReceiveMemberAndStatus(Member requester, Member receiver, FriendStatus status);
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
@@ -3,6 +3,7 @@ package com.samsamhajo.deepground.friend.repository;
 import com.samsamhajo.deepground.friend.entity.Friend;
 
 import com.samsamhajo.deepground.friend.entity.FriendStatus;
+import com.samsamhajo.deepground.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +11,7 @@ import java.util.List;
 
 @Repository
 public interface FriendRepository extends JpaRepository<Friend,Long> {
+
+    boolean existsByRequestMemberAndReceiveMember(Member requester, Member receiver);
 
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
@@ -5,9 +5,12 @@ import com.samsamhajo.deepground.friend.entity.Friend;
 import com.samsamhajo.deepground.friend.entity.FriendStatus;
 import com.samsamhajo.deepground.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+
 
 @Repository
 public interface FriendRepository extends JpaRepository<Friend,Long> {
@@ -15,4 +18,7 @@ public interface FriendRepository extends JpaRepository<Friend,Long> {
     boolean existsByRequestMemberAndReceiveMember(Member requester, Member receiver);
 
     boolean existsByRequestMemberAndReceiveMemberAndStatus(Member requester, Member receiver, FriendStatus status);
+
+    @Query("SELECT f FROM Friend f WHERE f.requestMember.id = :requesterId AND f.status = 'REQUEST'")
+    List<Friend> findSentRequests(@Param("requesterId") Long requesterId);
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -34,7 +34,7 @@ public class FriendService {
         if(requester.getEmail().equals(receiver.getEmail())) {
             throw new FriendException(FriendErrorCode.SELF_REQUEST);
         }
-        if(memberRepository.existsByRequestMemberAndReceiveMember(requester,receiver)) {
+        if(friendRepository.existsByRequestMemberAndReceiveMember(requester,receiver)) {
             throw new FriendException(FriendErrorCode.ALREADY_FRIEND);
         }
 

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -3,6 +3,7 @@ package com.samsamhajo.deepground.friend.service;
 import com.samsamhajo.deepground.friend.Exception.FriendException;
 import com.samsamhajo.deepground.friend.entity.Friend;
 import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
+import com.samsamhajo.deepground.friend.entity.FriendStatus;
 import com.samsamhajo.deepground.friend.repository.FriendRepository;
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
@@ -34,9 +35,13 @@ public class FriendService {
         if(requester.getEmail().equals(receiver.getEmail())) {
             throw new FriendException(FriendErrorCode.SELF_REQUEST);
         }
-        if(friendRepository.existsByRequestMemberAndReceiveMember(requester,receiver)) {
+        if(friendRepository.existsByRequestMemberAndReceiveMemberAndStatus(requester, receiver, FriendStatus.ACCEPT)) {
             throw new FriendException(FriendErrorCode.ALREADY_FRIEND);
         }
+        if(friendRepository.existsByRequestMemberAndReceiveMemberAndStatus(requester,receiver, FriendStatus.REQUEST)) {
+            throw new FriendException(FriendErrorCode.ALREADY_REQUESTED);
+        }
+
 
         Friend friend = Friend.request(requester, receiver);
         friendRepository.save(friend);

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.friend.service;
 
+import com.samsamhajo.deepground.friend.Dto.FriendDto;
 import com.samsamhajo.deepground.friend.Exception.FriendException;
 import com.samsamhajo.deepground.friend.entity.Friend;
 import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
@@ -10,6 +11,9 @@ import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -47,6 +51,13 @@ public class FriendService {
         friendRepository.save(friend);
 
         return friend.getId();
+    }
+    @Transactional
+    public List<FriendDto> findSentFriendRequest(Long requesterId) {
+        List<Friend> friends = friendRepository.findSentRequests(requesterId);
+        return friends.stream()
+                .map(FriendDto::fromSent)
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -38,9 +38,6 @@ public class FriendService {
             throw new FriendException(FriendErrorCode.ALREADY_FRIEND);
         }
 
-
-
-
         Friend friend = Friend.request(requester, receiver);
         friendRepository.save(friend);
 

--- a/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
@@ -11,7 +11,7 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
 
     Optional<Member> findByEmail(String email);
 
-    boolean existsByRequestMemberAndReceiveMember(Member requester, Member receiver);
+
 
     }
 

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendController/FriendRequestTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendController/FriendRequestTest.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.Friend.FriendController;
 
+import com.samsamhajo.deepground.friend.Dto.FriendDto;
 import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
 import com.samsamhajo.deepground.friend.Exception.FriendException;
 import com.samsamhajo.deepground.friend.entity.Friend;
@@ -16,8 +17,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -35,15 +37,22 @@ public class FriendRequestTest {
 
     private Member requester;
     private Member receiver;
+    private Member receiver2;
+    private Member receiver3;
 
     @BeforeEach
     void setup() {
         requester = Member.createLocalMember("paka@gamil.com", "pw", "파카");
         receiver = Member.createLocalMember("garden@gmail.com", "pw", "가든");
+        receiver2 =  Member.createLocalMember("gar@gmail.com", "pw", "가");
+        receiver3 = Member.createLocalMember("den@gmail.com", "pw", "든");
 
 
         memberRepository.save(requester);
         memberRepository.save(receiver);
+        memberRepository.save(receiver2);
+        memberRepository.save(receiver3);
+
     }
 
     @Test
@@ -105,6 +114,25 @@ public class FriendRequestTest {
                 friendService.sendFriendRequest(requester.getId(), receiver.getEmail()));
 
         assertEquals(FriendErrorCode.ALREADY_FRIEND, exception.getErrorCode());
+    }
+
+    @Test
+    public void 친구_목록() throws Exception {
+        //given
+        friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+        friendService.sendFriendRequest(requester.getId(), receiver2.getEmail());
+        friendService.sendFriendRequest(requester.getId(), receiver3.getEmail());
+        //when
+        List<FriendDto> sentList = friendService.findSentFriendRequest(requester.getId());
+
+        // then
+        assertEquals(3, sentList.size());
+
+
+        assertTrue(sentList.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver.getNickname())));
+        assertTrue(sentList.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver2.getNickname())));
+        assertTrue(sentList.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver3.getNickname())));
+
     }
 
 

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendController/FriendRequestTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendController/FriendRequestTest.java
@@ -6,12 +6,13 @@ import com.samsamhajo.deepground.friend.entity.Friend;
 import com.samsamhajo.deepground.friend.entity.FriendStatus;
 import com.samsamhajo.deepground.friend.repository.FriendRepository;
 import com.samsamhajo.deepground.friend.service.FriendService;
-import com.samsamhajo.deepground.global.error.core.BaseException;
+
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +31,8 @@ public class FriendRequestTest {
     @Autowired
     private FriendRepository friendRepository;
 
+
+
     private Member requester;
     private Member receiver;
 
@@ -37,6 +40,7 @@ public class FriendRequestTest {
     void setup() {
         requester = Member.createLocalMember("paka@gamil.com", "pw", "파카");
         receiver = Member.createLocalMember("garden@gmail.com", "pw", "가든");
+
 
         memberRepository.save(requester);
         memberRepository.save(receiver);
@@ -56,14 +60,52 @@ public class FriendRequestTest {
     }
 
     @Test
+    public void 없는_이메일_예외() throws Exception {
+        //given
+        friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+        //when,then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendFriendRequest(requester.getId(), "garde@gmail.com"));
+
+        assertEquals(FriendErrorCode.MEMBER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    public void 본인_계정에_친구_요청_예외() throws Exception {
+        //given
+        friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+
+        //when,then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendFriendRequest(requester.getId(), requester.getEmail()));
+        
+        assertEquals(FriendErrorCode.SELF_REQUEST, exception.getErrorCode());
+    }
+    @Test
     public void 중복_친구_요청예외() throws Exception {
         //given
+        friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+
+        //when,then
         FriendException exception = assertThrows(FriendException.class, () ->
                 friendService.sendFriendRequest(requester.getId(), receiver.getEmail()));
 
-        //when,then
-
         assertEquals(FriendErrorCode.ALREADY_REQUESTED, exception.getErrorCode());
-        }
+    }
+    @Test
+    public void 이미_친구_상태에서_요청시_예외() throws Exception {
+        //given
+        Friend friend = Friend.request(requester,receiver);
+        friend.accept();
+        friendRepository.save(friend);
+
+
+        //when,then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendFriendRequest(requester.getId(), receiver.getEmail()));
+
+        assertEquals(FriendErrorCode.ALREADY_FRIEND, exception.getErrorCode());
+    }
+
 
 }


### PR DESCRIPTION
## 📌 개요
친구 요청 목록을 조회하는 API를 구현하였습니다. 해당 기능을 통해 사용자가 자신이 보낸 친구 요청 목록을 확인할 수 있습니다

## 🛠️ 작업 내용
- `FriendRepository`에 JPQL 쿼리 메서드 추가
- 친구 요청 목록 API 구현
- 테스트 코드 작성

### 📌 친구 요청 목록 API
- 사용자가 보낸 친구 요청만 필터링해 조회합니다.

## 📌 차후 계획 (Optional)
- 받은 요청 목록 기능 별도 구현 예정
- 요청 수락/거절 API 추가 예정


## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수 확인
- 기존 테스트 통과
-
### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
-FriendService 단위 테스트에서는 예외 처리 케이스 필요 없음
---
closes #91 