### PR TITLE
[Feature] 친구 요청 취소 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
-//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-//	implementation 'org.springframework.security:spring-security-messaging'
+	implementation 'org.springframework.security:spring-security-messaging'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
@@ -44,7 +44,7 @@ dependencies {
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/samsamhajo/deepground/DeepgroundApplication.java
+++ b/src/main/java/com/samsamhajo/deepground/DeepgroundApplication.java
@@ -1,9 +1,16 @@
 package com.samsamhajo.deepground;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(
+		exclude = {
+				SecurityAutoConfiguration.class,
+				ManagementWebSecurityAutoConfiguration.class
+		}
+)
 public class DeepgroundApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
@@ -13,7 +13,9 @@ public enum FriendErrorCode implements ErrorCode {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "올바른 이메일 형식을 입력해주세요."),
     BLANK_EMAIL(HttpStatus.BAD_REQUEST, "친구요청을 보낼 이메일을 입력해주세요"),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "이미 친구로 등록된 사용자입니다."),
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "찾을 수 없는 사용자입니다");
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "찾을 수 없는 사용자입니다"),
+    REQUEST_NOT_FOUND(HttpStatus.BAD_REQUEST, "친구 요청이 존재하지 않습니다");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
@@ -13,8 +13,8 @@ public enum FriendErrorCode implements ErrorCode {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "올바른 이메일 형식을 입력해주세요."),
     BLANK_EMAIL(HttpStatus.BAD_REQUEST, "친구요청을 보낼 이메일을 입력해주세요"),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "이미 친구로 등록된 사용자입니다."),
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "찾을 수 없는 사용자입니다"),
-    REQUEST_NOT_FOUND(HttpStatus.BAD_REQUEST, "친구 요청이 존재하지 않습니다");
+    INVALID_MEMBER_EMAIL(HttpStatus.BAD_REQUEST, "찾을 수 없는 사용자입니다"),
+    INVALID_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "친구 요청이 존재하지 않습니다");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 
 @RestController
-@RequestMapping(("/api/v1/friends"))
+@RequestMapping(("/friends"))
 @RequiredArgsConstructor
 public class FriendController {
 

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -3,6 +3,7 @@ package com.samsamhajo.deepground.friend.controller;
 import com.samsamhajo.deepground.friend.Dto.FriendDto;
 import com.samsamhajo.deepground.friend.Dto.FriendRequestDto;
 import com.samsamhajo.deepground.friend.Dto.ResponseDto;
+import com.samsamhajo.deepground.friend.entity.FriendStatus;
 import com.samsamhajo.deepground.friend.service.FriendService;
 import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.validation.Valid;
@@ -16,7 +17,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 
-@RestController("/api/v1/friends")
+@RestController
+@RequestMapping(("/api/v1/friends"))
 @RequiredArgsConstructor
 public class FriendController {
 
@@ -37,6 +39,14 @@ public class FriendController {
     @GetMapping("/sent")
     public ResponseEntity<List<FriendDto>> getSentFriendRequests(@RequestParam Long requesterId) {
         return ResponseEntity.ok(friendService.findSentFriendRequest(requesterId));
+    }
+
+    @PatchMapping("/sent/{friendId}/cancel")
+    public ResponseEntity<ResponseDto> cancelFriendRequest(@PathVariable Long friendId,
+                                                           @RequestParam Long requesterId){
+        friendService.cancelFriendRequest(friendId,requesterId);
+        return ResponseEntity.ok().body(new ResponseDto(HttpStatus.OK, "친구 요청 취소가 되었습니다!",friendId));
+
     }
 
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/entity/Friend.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/entity/Friend.java
@@ -43,7 +43,7 @@ public class Friend extends BaseEntity {
       return new Friend (requestMember, receiveMember, FriendStatus.REQUEST);
     }
 
-    public void cancel() {
+    public void cancel(Long requesterId) {
         this.status = FriendStatus.CANCEL;
     }
 

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -30,11 +30,11 @@ public class FriendService {
     public Long sendFriendRequest (Long requesterId, String receiverEmail) {
 
         Member requester = memberRepository.findById(requesterId)
-                .orElseThrow(() -> new FriendException(FriendErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new FriendException(FriendErrorCode.INVALID_MEMBER_EMAIL));
 
 
         Member receiver = memberRepository.findByEmail(receiverEmail)
-                .orElseThrow(() -> new FriendException(FriendErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new FriendException(FriendErrorCode.INVALID_MEMBER_EMAIL));
 
         if(receiverEmail == null || receiverEmail.trim().isEmpty()){
             throw new FriendException(FriendErrorCode.BLANK_EMAIL);
@@ -48,7 +48,6 @@ public class FriendService {
         if(friendRepository.existsByRequestMemberAndReceiveMemberAndStatus(requester,receiver, FriendStatus.REQUEST)) {
             throw new FriendException(FriendErrorCode.ALREADY_REQUESTED);
         }
-
 
         Friend friend = Friend.request(requester, receiver);
         friendRepository.save(friend);
@@ -66,7 +65,7 @@ public class FriendService {
     @Transactional
     public Long cancelFriendRequest(Long friendId, Long requesterId) {
         Friend friendRequest = friendRepository.findById(friendId)
-                .orElseThrow(() -> new FriendException(FriendErrorCode.REQUEST_NOT_FOUND));
+                .orElseThrow(() -> new FriendException(FriendErrorCode. INVALID_FRIEND_REQUEST));
 
         friendRequest.cancel(requesterId);
 

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.friend.service;
 
 import com.samsamhajo.deepground.friend.Dto.FriendDto;
+
 import com.samsamhajo.deepground.friend.Exception.FriendException;
 import com.samsamhajo.deepground.friend.entity.Friend;
 import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
@@ -14,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.samsamhajo.deepground.friend.entity.FriendStatus.CANCEL;
 
 @Service
 @Transactional(readOnly = true)
@@ -60,6 +63,14 @@ public class FriendService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public Long cancelFriendRequest(Long friendId, Long requesterId) {
+        Friend friendRequest = friendRepository.findById(friendId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.REQUEST_NOT_FOUND));
 
+        friendRequest.cancel(requesterId);
 
+        return friendRequest.getId();
+
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,18 +56,18 @@ spring:
       host: ${MONGO_HOST}
       port: ${MONGO_PORT}
       database: ${MONGO_DATABASE}
-      username: ${MONGO_USERNAME}
-      password: ${MONGO_PASSWORD}
+#      username: ${MONGO_USERNAME}
+#      password: ${MONGO_PASSWORD}
       auto-index-creation: true
 
 # CORS 설정
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGIN}
-  allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+  allowed-methods: GET,POST,PUT,DELETE,OPTIONS,PATCH
   allowed-headers: '*'
   max-age: 3600
 
 # Swagger 설정
-#swagger:
-#  server:
-#    url: ${SWAGGER_SERVER_URL:http://localhost:8080/api/v1}
+swagger:
+  server:
+    url: http://localhost:8080

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendController/FriendRequestTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendController/FriendRequestTest.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.Friend.FriendController;
 
+import com.samsamhajo.deepground.friend.Dto.FriendDto;
 import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
 import com.samsamhajo.deepground.friend.Exception.FriendException;
 import com.samsamhajo.deepground.friend.entity.Friend;
@@ -16,8 +17,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -35,15 +37,22 @@ public class FriendRequestTest {
 
     private Member requester;
     private Member receiver;
+    private Member receiver2;
+    private Member receiver3;
 
     @BeforeEach
     void setup() {
         requester = Member.createLocalMember("paka@gamil.com", "pw", "파카");
         receiver = Member.createLocalMember("garden@gmail.com", "pw", "가든");
+        receiver2 =  Member.createLocalMember("gar@gmail.com", "pw", "가");
+        receiver3 = Member.createLocalMember("den@gmail.com", "pw", "든");
 
 
         memberRepository.save(requester);
         memberRepository.save(receiver);
+        memberRepository.save(receiver2);
+        memberRepository.save(receiver3);
+
     }
 
     @Test
@@ -105,6 +114,25 @@ public class FriendRequestTest {
                 friendService.sendFriendRequest(requester.getId(), receiver.getEmail()));
 
         assertEquals(FriendErrorCode.ALREADY_FRIEND, exception.getErrorCode());
+    }
+
+    @Test
+    public void 친구_목록() throws Exception {
+        //given
+        friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+        friendService.sendFriendRequest(requester.getId(), receiver2.getEmail());
+        friendService.sendFriendRequest(requester.getId(), receiver3.getEmail());
+        //when
+        List<FriendDto> sentList = friendService.findSentFriendRequest(requester.getId());
+
+        // then
+        assertEquals(3, sentList.size());
+
+
+        assertTrue(sentList.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver.getNickname())));
+        assertTrue(sentList.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver2.getNickname())));
+        assertTrue(sentList.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver3.getNickname())));
+
     }
 
 

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendRequestTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendRequestTest.java
@@ -74,7 +74,7 @@ public class FriendRequestTest {
         FriendException exception = assertThrows(FriendException.class, () ->
                 friendService.sendFriendRequest(requester.getId(), "garde@gmail.com"));
 
-        assertEquals(FriendErrorCode.MEMBER_NOT_FOUND, exception.getErrorCode());
+        assertEquals(FriendErrorCode.INVALID_MEMBER_EMAIL, exception.getErrorCode());
     }
 
     @Test
@@ -157,7 +157,7 @@ public class FriendRequestTest {
             friendService.cancelFriendRequest(invalidFriendId, requester.getId());
         });
         //then
-        assertEquals(FriendErrorCode.REQUEST_NOT_FOUND, exception.getErrorCode());
+        assertEquals(FriendErrorCode.INVALID_FRIEND_REQUEST, exception.getErrorCode());
     }
 
 

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendRequestTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendRequestTest.java
@@ -1,4 +1,4 @@
-package com.samsamhajo.deepground.Friend.FriendController;
+package com.samsamhajo.deepground.Friend;
 
 import com.samsamhajo.deepground.friend.Dto.FriendDto;
 import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
@@ -13,7 +13,6 @@ import com.samsamhajo.deepground.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,7 +33,6 @@ public class FriendRequestTest {
     private FriendRepository friendRepository;
 
 
-
     private Member requester;
     private Member receiver;
     private Member receiver2;
@@ -44,7 +42,7 @@ public class FriendRequestTest {
     void setup() {
         requester = Member.createLocalMember("paka@gamil.com", "pw", "파카");
         receiver = Member.createLocalMember("garden@gmail.com", "pw", "가든");
-        receiver2 =  Member.createLocalMember("gar@gmail.com", "pw", "가");
+        receiver2 = Member.createLocalMember("gar@gmail.com", "pw", "가");
         receiver3 = Member.createLocalMember("den@gmail.com", "pw", "든");
 
 
@@ -87,9 +85,10 @@ public class FriendRequestTest {
         //when,then
         FriendException exception = assertThrows(FriendException.class, () ->
                 friendService.sendFriendRequest(requester.getId(), requester.getEmail()));
-        
+
         assertEquals(FriendErrorCode.SELF_REQUEST, exception.getErrorCode());
     }
+
     @Test
     public void 중복_친구_요청예외() throws Exception {
         //given
@@ -101,10 +100,11 @@ public class FriendRequestTest {
 
         assertEquals(FriendErrorCode.ALREADY_REQUESTED, exception.getErrorCode());
     }
+
     @Test
     public void 이미_친구_상태에서_요청시_예외() throws Exception {
         //given
-        Friend friend = Friend.request(requester,receiver);
+        Friend friend = Friend.request(requester, receiver);
         friend.accept();
         friendRepository.save(friend);
 
@@ -133,6 +133,31 @@ public class FriendRequestTest {
         assertTrue(sentList.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver2.getNickname())));
         assertTrue(sentList.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver3.getNickname())));
 
+    }
+
+    @Test
+    public void 친구_요청_취소() throws Exception {
+        //given
+        friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+        List<FriendDto> sentList = friendService.findSentFriendRequest(requester.getId());
+        Long friendId = sentList.get(0).getFriendId();
+        //when
+        Long cancel = friendService.cancelFriendRequest(friendId, requester.getId());
+
+        //then
+        assertEquals(friendId, cancel);
+    }
+
+    @Test
+    public void 친구_요청_취소_존재하지_않는_friendId_예외() throws Exception {
+        //given
+        Long invalidFriendId = 231L;
+        //when
+        FriendException exception = assertThrows(FriendException.class, () -> {
+            friendService.cancelFriendRequest(invalidFriendId, requester.getId());
+        });
+        //then
+        assertEquals(FriendErrorCode.REQUEST_NOT_FOUND, exception.getErrorCode());
     }
 
 


### PR DESCRIPTION
## 📌 개요
친구 요청을 취소하는 API를 구현하였습니다. 해당 기능을통해 사용자가 자신이 보낸 친구 요청에 대해서 취소할 수 있습니다.

## 🛠️ 작업 내용
- 친구 요청 취소 API 구현 (`cancelFriendRequest`)
- 서비스 로직 구현 (`cancelFriendRequest`)
- 친구 요청 취소 에러 코드 작성(`REQUEST_NOT_FOUND`)

## 📌 차후 계획 (Optional)
- 친구 요청 목록 조회 시 실시간으로 반영되는지 검증
- 친구 요청 취소 시 알림 연동 검토

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수 확인
- 기존  테스트 전부 통과 

### 📌 기타 참고 사항
- 추가 예외 사항에 대해서 확인 

---

Closes #92 