### PR TITLE
[Feature] 받은 친구 요청 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/friend/Dto/FriendDto.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Dto/FriendDto.java
@@ -26,4 +26,12 @@ public class FriendDto {
         );
     }
 
+    public static FriendDto fromReceived(Friend friend) {
+        return new FriendDto(
+                friend.getId(),
+                friend.getRequestMember().getNickname(),
+                friend.getStatus()
+        );
+    }
+
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -7,8 +7,6 @@ import com.samsamhajo.deepground.friend.Exception.FriendSuccessCode;
 import com.samsamhajo.deepground.friend.service.FriendService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import jakarta.validation.Valid;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -44,6 +42,11 @@ public class FriendController {
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_CANCEL,friendId));
 
+    }
+
+    @GetMapping("/receive")
+    public ResponseEntity<List<FriendDto>> getReceiveFriendRequests(@RequestParam Long receiverId) {
+        return ResponseEntity.ok(friendService.findFriendReceive(receiverId));
     }
 
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
@@ -22,4 +22,6 @@ public interface FriendRepository extends JpaRepository<Friend,Long> {
     @Query("SELECT f FROM Friend f WHERE f.requestMember.id = :requesterId AND f.status = 'REQUEST'")
     List<Friend> findSentRequests(@Param("requesterId") Long requesterId);
 
+    @Query("SELECT f FROM Friend f WHERE f.receiveMember.id = :receiverId AND f.status = 'REQUEST'")
+    List<Friend> findReceiveRequests(@Param("receiverId") Long receiverId);
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -70,5 +69,12 @@ public class FriendService {
 
         return friendRequest.getId();
 
+    }
+
+    public List<FriendDto> findFriendReceive (Long receiverId) {
+        List<Friend> friends = friendRepository.findReceiveRequests(receiverId);
+        return friends.stream()
+                .map(FriendDto::fromReceived)
+                .toList();
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -54,7 +54,6 @@ public class FriendService {
             throw new FriendException(FriendErrorCode.ALREADY_REQUESTED);
         }
     }
-    @Transactional
     public List<FriendDto> findSentFriendRequest(Long requesterId) {
         List<Friend> friends = friendRepository.findSentRequests(requesterId);
         return friends.stream()

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendReceiveTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendReceiveTest.java
@@ -1,0 +1,74 @@
+package com.samsamhajo.deepground.Friend.FriendService;
+
+import com.samsamhajo.deepground.friend.Dto.FriendDto;
+import com.samsamhajo.deepground.friend.repository.FriendRepository;
+import com.samsamhajo.deepground.friend.service.FriendService;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+public class FriendReceiveTest {
+
+    @Autowired
+    private FriendService friendService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+
+    private Member requester;
+    private Member requester2;
+    private Member requester3;
+    private Member receiver;
+
+
+    @BeforeEach
+    void setup() {
+        requester = Member.createLocalMember("paka@gamil.com", "pw", "파카");
+        requester2 = Member.createLocalMember("gar@gmail.com", "pw", "가");
+        requester3 = Member.createLocalMember("den@gmail.com", "pw", "든");
+        receiver = Member.createLocalMember("garden@gmail.com", "pw", "가든");
+
+
+
+        memberRepository.save(requester);
+        memberRepository.save(requester3);
+        memberRepository.save(requester2);
+        memberRepository.save(receiver);
+
+    }
+
+    @Test
+    public void 받은_친구_요청_목록() throws Exception {
+        //given
+        friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+        friendService.sendFriendRequest(requester2.getId(), receiver.getEmail());
+        friendService.sendFriendRequest(requester3.getId(), receiver.getEmail());
+        //when
+        List<FriendDto> receiveList = friendService.findFriendReceive(receiver.getId());
+        //then
+        assertEquals(3, receiveList.size());
+
+
+        assertTrue(receiveList.stream().anyMatch(f -> f.getOtherMemberName().equals(requester.getNickname())));
+        assertTrue(receiveList.stream().anyMatch(f -> f.getOtherMemberName().equals(requester2.getNickname())));
+        assertTrue(receiveList.stream().anyMatch(f -> f.getOtherMemberName().equals(requester3.getNickname())));
+
+    }
+
+
+}


### PR DESCRIPTION
## 📌 개요
받은 친구 요청 목록에 대해서 조회하는 기능을 구현하였니다

## 🛠️ 작업 내용
- `FriendRepository`에 JPQL쿼리 메서드 추가(`findReceiveRequests`)
- 받은 친구 요청 목록 API 구현(`getReceiveFriendRequests`)
- `FriendDto` 정적 팩토리 메서드(`fromReceived`) 추가
- 받은 친구 요청 목록 서비스 로직 구현 (`findFriendReceive`)
- 테스트 코드 작성
### 📌 받은 친구 요청 목록 API 
- 받은 친구 요청에 대한 목록을 조회합니다.
- 쿼리 작성(`findReceiveRequests`)
receiverId가 일치하고, 상태가 "REQUEST"인 친구 요청만 조회합니다

## 📌 차후 계획 (Optional)
- 요청 수락/거절 API 추가 예정
- 요청이 수락/거절, 요청 취소에 대한 친구 받은 요청 목록에서 제외 테스트 확인 예정

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수
- 기존 테스트 통과
closes #94