### PR TITLE
[Feature] 친구 요청 수락 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
@@ -14,7 +14,8 @@ public enum FriendErrorCode implements ErrorCode {
     BLANK_EMAIL(HttpStatus.BAD_REQUEST, "친구요청을 보낼 이메일을 입력해주세요"),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "이미 친구로 등록된 사용자입니다."),
     INVALID_MEMBER_EMAIL(HttpStatus.BAD_REQUEST, "찾을 수 없는 사용자입니다"),
-    INVALID_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "친구 요청이 존재하지 않습니다");
+    INVALID_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "친구 요청이 존재하지 않습니다"),
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "다른 사용자의 친구 요청은 수락할 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendSuccessCode.java
@@ -8,8 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum FriendSuccessCode implements SuccessCode {
     FRIEND_SUCCESS_REQUEST(HttpStatus.OK, "친구 요청이 성공적으로 전송되었습니다."),
     FRIEND_SUCCESS_CANCEL(HttpStatus.OK, "친구 요청이 취소되었습니다 "),
-
-    ;
+    FRIEND_SUCCESS_ACCEPT(HttpStatus.OK,"친구 요청을 수락했습니다" );
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -6,6 +6,7 @@ import com.samsamhajo.deepground.friend.Dto.FriendRequestDto;
 import com.samsamhajo.deepground.friend.Exception.FriendSuccessCode;
 import com.samsamhajo.deepground.friend.service.FriendService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -45,5 +46,15 @@ public class FriendController {
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_CANCEL,friendId));
 
     }
+
+    @PatchMapping("/receive/{friendId}/accept")
+    public ResponseEntity<SuccessResponse> acceptFriendRequest(@PathVariable Long friendId,
+                                                               @RequestParam Member receiverId){
+        friendService.acceptFriendRequest(friendId, receiverId);
+        return ResponseEntity
+                .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_ACCEPT,friendId));
+    }
+
+
 
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -49,10 +49,10 @@ public class FriendController {
 
     @PatchMapping("/receive/{friendId}/accept")
     public ResponseEntity<SuccessResponse> acceptFriendRequest(@PathVariable Long friendId,
-                                                               @RequestParam Member receiverId){
-        friendService.acceptFriendRequest(friendId, receiverId);
+                                                               @RequestParam Long receiverId){
+        Long result = friendService.acceptFriendRequest(friendId, receiverId);
         return ResponseEntity
-                .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_ACCEPT,friendId));
+                .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_ACCEPT,result));
     }
 
 

--- a/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
@@ -22,4 +22,5 @@ public interface FriendRepository extends JpaRepository<Friend,Long> {
     @Query("SELECT f FROM Friend f WHERE f.requestMember.id = :requesterId AND f.status = 'REQUEST'")
     List<Friend> findSentRequests(@Param("requesterId") Long requesterId);
 
+    boolean existsByIdAndReceiveMemberAndStatus(Long id, Member receiveMember, FriendStatus status);
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -7,6 +7,8 @@ import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
 import com.samsamhajo.deepground.friend.entity.FriendStatus;
 import com.samsamhajo.deepground.friend.repository.FriendRepository;
 import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.exception.MemberErrorCode;
+import com.samsamhajo.deepground.member.exception.MemberException;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -73,7 +75,10 @@ public class FriendService {
     }
 
     @Transactional
-    public Long acceptFriendRequest(Long friendId, Member receiver) {
+    public Long acceptFriendRequest(Long friendId, Long receiverId) {
+        Member receiver = memberRepository.findById(receiverId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
         Friend friendRequest = validateAccept(friendId, receiver);
 
         friendRequest.accept();

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -71,5 +70,29 @@ public class FriendService {
 
         return friendRequest.getId();
 
+    }
+
+    @Transactional
+    public Long acceptFriendRequest(Long friendId, Member receiver) {
+        Friend friendRequest = validateAccept(friendId, receiver);
+
+        friendRequest.accept();
+
+        return friendRequest.getId();
+    }
+    private Friend validateAccept(Long friendId, Member receiver){
+        Friend friendRequest = friendRepository.findById(friendId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.INVALID_FRIEND_REQUEST));
+
+        if (!friendRequest.getReceiveMember().equals(receiver)) {
+            throw new FriendException(FriendErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        if(friendRepository.existsByIdAndReceiveMemberAndStatus(friendId, receiver,FriendStatus.ACCEPT)) {
+            throw new FriendException(FriendErrorCode.ALREADY_FRIEND);
+        }
+
+
+        return friendRequest;
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/member/exception/MemberErrorCode.java
@@ -1,0 +1,24 @@
+package com.samsamhajo.deepground.member.exception;
+
+import com.samsamhajo.deepground.global.error.core.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 사용자가 없습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[FRIEND ERROR]" + message;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/member/exception/MemberException.java
+++ b/src/main/java/com/samsamhajo/deepground/member/exception/MemberException.java
@@ -1,0 +1,8 @@
+package com.samsamhajo.deepground.member.exception;
+
+import com.samsamhajo.deepground.global.error.core.BaseException;
+
+public class MemberException extends BaseException {
+
+    public MemberException(MemberErrorCode errorCode) {super(errorCode);}
+}

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendReceiveTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendReceiveTest.java
@@ -55,6 +55,7 @@ public class FriendReceiveTest {
         memberRepository.save(requester3);
         memberRepository.save(requester2);
         memberRepository.save(receiver);
+        memberRepository.save(receiver2);
 
     }
 
@@ -64,7 +65,7 @@ public class FriendReceiveTest {
         Long friendId = friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
 
         //when
-        Long accept = friendService.acceptFriendRequest(friendId, receiver);
+        Long accept = friendService.acceptFriendRequest(friendId, receiver.getId());
 
         //then
         assertEquals(friendId ,accept);
@@ -77,7 +78,7 @@ public class FriendReceiveTest {
 
         //when
         FriendException exception = assertThrows(FriendException.class, () ->
-                friendService.acceptFriendRequest(friendId, receiver2));
+                friendService.acceptFriendRequest(friendId, receiver2.getId()));
         //then
         assertEquals(FriendErrorCode.UNAUTHORIZED_ACCESS, exception.getErrorCode());
         }
@@ -91,7 +92,7 @@ public class FriendReceiveTest {
 
         //when,then
         FriendException exception = assertThrows(FriendException.class, () ->
-                friendService.acceptFriendRequest(friend.getId(), receiver));
+                friendService.acceptFriendRequest(friend.getId(), receiver.getId()));
 
         assertEquals(FriendErrorCode.ALREADY_FRIEND, exception.getErrorCode());
     }

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendReceiveTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendReceiveTest.java
@@ -1,0 +1,100 @@
+package com.samsamhajo.deepground.Friend.FriendService;
+
+import com.samsamhajo.deepground.friend.Dto.FriendDto;
+import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
+import com.samsamhajo.deepground.friend.Exception.FriendException;
+import com.samsamhajo.deepground.friend.entity.Friend;
+import com.samsamhajo.deepground.friend.entity.FriendStatus;
+import com.samsamhajo.deepground.friend.repository.FriendRepository;
+import com.samsamhajo.deepground.friend.service.FriendService;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+public class FriendReceiveTest {
+
+    @Autowired
+    private FriendService friendService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+
+    private Member requester;
+    private Member requester2;
+    private Member requester3;
+    private Member receiver;
+    private Member receiver2;
+
+
+    @BeforeEach
+    void setup() {
+        requester = Member.createLocalMember("paka@gamil.com", "pw", "파카");
+        requester2 = Member.createLocalMember("gar@gmail.com", "pw", "가");
+        requester3 = Member.createLocalMember("den@gmail.com", "pw", "든");
+        receiver = Member.createLocalMember("garden@gmail.com", "pw", "가든");
+        receiver2 = Member.createLocalMember("pa@gmail.com","pw","파카");
+
+
+
+        memberRepository.save(requester);
+        memberRepository.save(requester3);
+        memberRepository.save(requester2);
+        memberRepository.save(receiver);
+
+    }
+
+    @Test
+    public void 친구_요청_수락() throws Exception {
+        //given
+        Long friendId = friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+
+        //when
+        Long accept = friendService.acceptFriendRequest(friendId, receiver);
+
+        //then
+        assertEquals(friendId ,accept);
+    }
+
+    @Test
+    public void 다른_사용자_수락_예외() throws Exception {
+        //given
+        Long friendId = friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+
+        //when
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.acceptFriendRequest(friendId, receiver2));
+        //then
+        assertEquals(FriendErrorCode.UNAUTHORIZED_ACCESS, exception.getErrorCode());
+        }
+
+    @Test
+    public void 이미_친구_상태에서_수락시_예외() throws Exception {
+        //given
+        Friend friend = Friend.request(requester, receiver);
+        friend.accept();
+        friendRepository.save(friend);
+
+        //when,then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.acceptFriendRequest(friend.getId(), receiver));
+
+        assertEquals(FriendErrorCode.ALREADY_FRIEND, exception.getErrorCode());
+    }
+
+
+}


### PR DESCRIPTION
## 📌 개요
친구 요청 수락 기능을 구현했습니다

## 🛠️ 작업 내용
- 친구 요청 수락 API 구현 (`acceptFriendRequest`)
- 친구 요청 수락 서비스 로직 구현 
- 친구 요청 수락 관련 예외 로직 추가
- 친구 요청의 ID, 수신자, 상태 값을 기준으로 특정 상태의 친구 관계 여부를 확인할 수 있는 쿼리 메서드(existsByIdAndReceiveMemberAndStatus) 작성
- 테스트 코드 작성

### 📌친구 요청 수락 API
- 친구 요청에 대해서 수락 처리를 수 있습니다
- 수락 시, `Friend` 엔티티의 상태를 `"ACCEPT"`로 변경합니다.
-  쿼리 작성(acceptFriendRequest) 및 쿼리 메서드 사용

## 📌 차후 계획 (Optional)
-  친구 수락 후:
   - 친구 목록에서 정상 조회 여부 확인
   - 보낸 친구 요청 목록 및 받은 친구 요청 목록에서 제외되는 확인 

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수
- 기존 테스트 통과 

### 📌 기타 참고 사항
- 추가한 필요한 예외 사항이 있는지 확인해주시면 감사하겠습니다

---
closes #96 