### PR TITLE
[Refactor] 스케줄 도메인 관련 응답 표준화 리팩토링

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/controller/StudyScheduleController.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/controller/StudyScheduleController.java
@@ -2,7 +2,9 @@ package com.samsamhajo.deepground.calendar.controller;
 
 import com.samsamhajo.deepground.calendar.dto.StudyScheduleRequestDto;
 import com.samsamhajo.deepground.calendar.dto.StudyScheduleResponseDto;
+import com.samsamhajo.deepground.calendar.exception.ScheduleSuccessCode;
 import com.samsamhajo.deepground.calendar.service.StudyScheduleService;
+import com.samsamhajo.deepground.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,12 +18,13 @@ public class StudyScheduleController {
     private final StudyScheduleService studyScheduleService;
 
     @PostMapping("/schedules")
-    public ResponseEntity<StudyScheduleResponseDto> createSchedule(
+    public ResponseEntity<SuccessResponse<StudyScheduleResponseDto>> createSchedule(
             @PathVariable Long studyGroupId,
             @Valid @RequestBody StudyScheduleRequestDto requestDto
     ) {
         StudyScheduleResponseDto responseDto = studyScheduleService.createStudySchedule(studyGroupId, requestDto);
-        return ResponseEntity.ok(responseDto);
+        return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_CREATED.getStatus())
+                .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_CREATED, responseDto));
     }
 
 

--- a/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleErrorCode.java
@@ -1,0 +1,21 @@
+package com.samsamhajo.deepground.calendar.exception;
+
+import com.samsamhajo.deepground.global.error.core.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ScheduleErrorCode implements ErrorCode {
+    DUPLICATE_SCHEDULE(HttpStatus.CONFLICT, "이미 같은 시간대에 등록된 일정이 있습니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "종료 시간이 시작 시간보다 늦을 수 없습니다."),
+    MISSING_REQUIRED_FIELDS(HttpStatus.BAD_REQUEST, "필수 입력 값이 누락되었습니다."),
+    NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, "요청한 일정을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ScheduleErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleException.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleException.java
@@ -1,0 +1,8 @@
+package com.samsamhajo.deepground.calendar.exception;
+
+import com.samsamhajo.deepground.global.error.core.BaseException;
+import com.samsamhajo.deepground.global.error.core.ErrorCode;
+
+public class ScheduleException extends BaseException {
+    public ScheduleException(ErrorCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleSuccessCode.java
@@ -1,0 +1,18 @@
+package com.samsamhajo.deepground.calendar.exception;
+
+import com.samsamhajo.deepground.global.success.SuccessCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ScheduleSuccessCode implements SuccessCode {
+    SCHEDULE_CREATED(HttpStatus.CREATED, "일정이 성공적으로 등록되었습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ScheduleSuccessCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
@@ -3,10 +3,11 @@ package com.samsamhajo.deepground.calendar.service;
 import com.samsamhajo.deepground.calendar.dto.StudyScheduleRequestDto;
 import com.samsamhajo.deepground.calendar.dto.StudyScheduleResponseDto;
 import com.samsamhajo.deepground.calendar.entity.StudySchedule;
+import com.samsamhajo.deepground.calendar.exception.ScheduleErrorCode;
+import com.samsamhajo.deepground.calendar.exception.ScheduleException;
 import com.samsamhajo.deepground.calendar.repository.StudyScheduleRepository;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,10 +49,10 @@ public class StudyScheduleService {
     private StudyGroup validateSchedule(Long studyGroupId, StudyScheduleRequestDto requestDto) {
 
         StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
-                .orElseThrow(() -> new EntityNotFoundException("스터디 그룹이 존재하지 않습니다."));
+                .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.NOT_FOUND_SCHEDULE));
 
         if (requestDto.getEndTime().isBefore(requestDto.getStartTime())) {
-            throw new IllegalArgumentException("종료 시간이 시작 시간보다 늦을 수 없습니다.");
+            throw new ScheduleException(ScheduleErrorCode.INVALID_DATE_RANGE);
         }
 
         boolean isDuplicated = studyScheduleRepository.existsByStudyGroupAndEndTimeGreaterThanAndStartTimeLessThan(
@@ -61,7 +62,7 @@ public class StudyScheduleService {
         );
 
         if (isDuplicated) {
-            throw new IllegalStateException("해당 시간에 이미 스터디 스케줄이 존재합니다.");
+            throw new ScheduleException(ScheduleErrorCode.DUPLICATE_SCHEDULE);
         }
 
         return studyGroup;

--- a/src/test/java/com/samsamhajo/deepground/calendar/controller/StudyScheduleControllerTest.java
+++ b/src/test/java/com/samsamhajo/deepground/calendar/controller/StudyScheduleControllerTest.java
@@ -8,9 +8,11 @@ import com.samsamhajo.deepground.calendar.service.StudyScheduleService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -22,7 +24,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = StudyScheduleController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 public class StudyScheduleControllerTest {
 
     @Autowired
@@ -40,6 +43,7 @@ public class StudyScheduleControllerTest {
     }
 
     @Test
+    @WithMockUser(username = "testUser")
     void createStudySchedule_Success() throws Exception {
         // given
         StudyScheduleRequestDto requestDto = StudyScheduleRequestDto.builder()
@@ -63,16 +67,16 @@ public class StudyScheduleControllerTest {
                 .thenReturn(responseDto);
 
         // when & then
-        mockMvc.perform(post("/study-group/1/schedules", 1L)
+        mockMvc.perform(post("/study-group/{studyGroupId}/schedules", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.title").value("Spring Boot Study"))
-                .andExpect(jsonPath("$.startTime").value("2025-05-20T14:00:00"))
-                .andExpect(jsonPath("$.endTime").value("2025-05-20T16:00:00"))
-                .andExpect(jsonPath("$.description").value("Spring Boot 학습"))
-                .andExpect(jsonPath("$.location").value("온라인"));
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.result.id").value(1L))
+                .andExpect(jsonPath("$.result.title").value("Spring Boot Study"))
+                .andExpect(jsonPath("$.result.startTime").value("2025-05-20T14:00:00"))
+                .andExpect(jsonPath("$.result.endTime").value("2025-05-20T16:00:00"))
+                .andExpect(jsonPath("$.result.description").value("Spring Boot 학습"))
+                .andExpect(jsonPath("$.result.location").value("온라인"));
 
     }
 }

--- a/src/test/java/com/samsamhajo/deepground/calendar/service/StudyScheduleServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/calendar/service/StudyScheduleServiceTest.java
@@ -3,10 +3,11 @@ package com.samsamhajo.deepground.calendar.service;
 import com.samsamhajo.deepground.calendar.dto.StudyScheduleRequestDto;
 import com.samsamhajo.deepground.calendar.dto.StudyScheduleResponseDto;
 import com.samsamhajo.deepground.calendar.entity.StudySchedule;
+import com.samsamhajo.deepground.calendar.exception.ScheduleErrorCode;
+import com.samsamhajo.deepground.calendar.exception.ScheduleException;
 import com.samsamhajo.deepground.calendar.repository.StudyScheduleRepository;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -102,8 +103,8 @@ class StudyScheduleServiceTest {
 
         // when & then
         assertThatThrownBy(() -> studyScheduleService.createStudySchedule(1L, requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("종료 시간이 시작 시간보다 늦을 수 없습니다.");
+                .isInstanceOf(ScheduleException.class)
+                .hasMessageContaining(ScheduleErrorCode.INVALID_DATE_RANGE.getMessage());
 
         verify(studyScheduleRepository, never()).save(any(StudySchedule.class));
     }
@@ -115,8 +116,8 @@ class StudyScheduleServiceTest {
 
         // when & then
         assertThatThrownBy(() -> studyScheduleService.createStudySchedule(1L, requestDto))
-                .isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("스터디 그룹이 존재하지 않습니다.");
+                .isInstanceOf(ScheduleException.class)
+                .hasMessageContaining(ScheduleErrorCode.NOT_FOUND_SCHEDULE.getMessage());
 
         verify(studyScheduleRepository, never()).save(any(StudySchedule.class));
     }
@@ -133,8 +134,8 @@ class StudyScheduleServiceTest {
 
         // when & then
         assertThatThrownBy(() -> studyScheduleService.createStudySchedule(1L, requestDto))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("해당 시간에 이미 스터디 스케줄이 존재합니다.");
+                .isInstanceOf(ScheduleException.class)
+                .hasMessageContaining(ScheduleErrorCode.DUPLICATE_SCHEDULE.getMessage());
 
         verify(studyScheduleRepository, never()).save(any(StudySchedule.class));
     }


### PR DESCRIPTION

## 📌 개요

* StudyScheduleController와 StudyScheduleService의 응답 표준화를 위한 리팩토링 작업을 진행하였습니다.

## 🛠️ 작업 내용
- [x] 기존 응답 형식을 DTO로 래핑하여 표준화된 응답 구조로 변경
- [x] 예외 처리 시 표준화된 에러 응답 구조 적용 (ErrorResponse 활용)
- [x] StudyScheduleController에서 서비스 호출 시 표준 응답을 반환하도록 변경
- [x] StudyScheduleService에서 로직 처리 후 DTO에 상태 코드와 메시지를 함께 전달
- [x] 관련 이슈 번호 (#173)


## 📌 차후 계획 (Optional)

* 일정 조회 및 삭제 API 작성


## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인


#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
closes #173 