### PR TITLE
[Feature] 프로필에서 친구 요청 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
@@ -14,8 +14,9 @@ public enum FriendErrorCode implements ErrorCode {
     BLANK_EMAIL(HttpStatus.BAD_REQUEST, "친구요청을 보낼 이메일을 입력해주세요"),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "이미 친구로 등록된 사용자입니다."),
     INVALID_MEMBER_EMAIL(HttpStatus.BAD_REQUEST, "찾을 수 없는 사용자입니다"),
-    INVALID_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "친구 요청이 존재하지 않습니다");
-
+    INVALID_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "친구 요청이 존재하지 않습니다"),
+    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),
+    REQUEST_ALREADY_RECEIVED(HttpStatus.BAD_REQUEST, "상대방이 이미 친구 요청을 보냈습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -6,11 +6,11 @@ import com.samsamhajo.deepground.friend.Dto.FriendRequestDto;
 import com.samsamhajo.deepground.friend.Exception.FriendSuccessCode;
 import com.samsamhajo.deepground.friend.service.FriendService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.validation.Valid;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -44,6 +44,14 @@ public class FriendController {
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_CANCEL,friendId));
 
+    }
+
+    @PostMapping("/from-profile/{receiverId}")
+    public ResponseEntity<SuccessResponse> requestProfileFriend(@PathVariable Long receiverId,
+                                                                @AuthenticationPrincipal Member requester) {
+        Long friendId = friendService.sendProfileFriendRequest(requester.getId(), receiverId);
+        return ResponseEntity
+                .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_REQUEST,friendId));
     }
 
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -65,11 +65,43 @@ public class FriendService {
     @Transactional
     public Long cancelFriendRequest(Long friendId, Long requesterId) {
         Friend friendRequest = friendRepository.findById(friendId)
-                .orElseThrow(() -> new FriendException(FriendErrorCode. INVALID_FRIEND_REQUEST));
+                .orElseThrow(() -> new FriendException(FriendErrorCode.INVALID_FRIEND_REQUEST));
 
         friendRequest.cancel(requesterId);
 
         return friendRequest.getId();
 
+    }
+
+    public Long sendProfileFriendRequest(Long requesterId, Long receiverId) {
+
+        Member requester = memberRepository.findById(requesterId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.INVALID_MEMBER_ID));
+
+        Member receiver = memberRepository.findById(receiverId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.INVALID_MEMBER_ID));
+
+        validateSendProfileRequest(requester, receiver);
+
+        Friend friend = Friend.request(requester, receiver);
+        friendRepository.save(friend);
+
+        return friend.getId();
+    }
+
+    private void validateSendProfileRequest(Member requester, Member receiver) {
+
+        if (requester.getId().equals(receiver.getId())) {
+            throw new FriendException(FriendErrorCode.SELF_REQUEST);
+        }
+        if (friendRepository.existsByRequestMemberAndReceiveMemberAndStatus(requester, receiver, FriendStatus.ACCEPT)) {
+            throw new FriendException(FriendErrorCode.ALREADY_FRIEND);
+        }
+        if (friendRepository.existsByRequestMemberAndReceiveMemberAndStatus(requester, receiver, FriendStatus.REQUEST)) {
+            throw new FriendException(FriendErrorCode.ALREADY_REQUESTED);
+        }
+        if (friendRepository.existsByRequestMemberAndReceiveMemberAndStatus(receiver, requester, FriendStatus.REQUEST)) {
+            throw new FriendException(FriendErrorCode.REQUEST_ALREADY_RECEIVED);
+        }
     }
 }

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendRequestTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendRequestTest.java
@@ -160,5 +160,96 @@ public class FriendRequestTest {
         assertEquals(FriendErrorCode.INVALID_FRIEND_REQUEST, exception.getErrorCode());
     }
 
+    @Test
+    public void 프로필_친구_요청() throws Exception {
+        //given
+        Long friendId = friendService.sendProfileFriendRequest(requester.getId(), receiver.getId());
+        //when
+        Friend saved = friendRepository.findById(friendId).get();
+
+        //then
+        assertEquals(requester.getId(), saved.getRequestMember().getId());
+        assertEquals(receiver.getId(), saved.getReceiveMember().getId());
+        assertEquals(FriendStatus.REQUEST, saved.getStatus());
+    }
+
+    @Test
+    public void 존재하지_않는_요청자_ID일_때_예외발생_프로필() {
+        // given
+        Long invalidRequesterId = 99L; // 실제 존재하지 않는 ID
+
+        // when & then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendProfileFriendRequest(invalidRequesterId, receiver.getId())
+        );
+
+        assertEquals(FriendErrorCode.INVALID_MEMBER_ID, exception.getErrorCode());
+    }
+
+    @Test
+    public void 존재하지_않는_응답자자_ID일_때_예외발생_프로필() {
+        // given
+        Long invalidReceiverId = 99L; // 실제 존재하지 않는 ID
+
+        // when & then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendProfileFriendRequest(requester.getId(), invalidReceiverId)
+        );
+
+        assertEquals(FriendErrorCode.INVALID_MEMBER_ID, exception.getErrorCode());
+    }
+
+    @Test
+    public void 본인_계정에_프로필_친구_요청_예외() throws Exception {
+        //given
+        friendService.sendProfileFriendRequest(requester.getId(), receiver.getId());
+
+        //when,then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendProfileFriendRequest(requester.getId(), requester.getId()));
+
+        assertEquals(FriendErrorCode.SELF_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    public void 이미_친구_상태에서_포로필_친구_요청시_예외() throws Exception {
+        //given
+        Friend friend = Friend.request(requester, receiver);
+        friend.accept();
+        friendRepository.save(friend);
+
+        //when,then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendProfileFriendRequest(requester.getId(), receiver.getId()));
+
+        assertEquals(FriendErrorCode.ALREADY_FRIEND, exception.getErrorCode());
+    }
+
+    @Test
+    public void 중복_친구_요청_프로필_예외() throws Exception {
+        //given
+        friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+
+        //when,then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendProfileFriendRequest(requester.getId(), receiver.getId()));
+
+        assertEquals(FriendErrorCode.ALREADY_REQUESTED, exception.getErrorCode());
+    }
+
+    @Test
+    public void 상대방_이미_보낸_친구_요청_프로필() throws Exception {
+        //given
+        friendService.sendFriendRequest(receiver.getId(), requester.getEmail());
+
+        //when,then
+        FriendException exception = assertThrows(FriendException.class, () ->
+                friendService.sendProfileFriendRequest(requester.getId(), receiver.getId()));
+
+        assertEquals(FriendErrorCode.REQUEST_ALREADY_RECEIVED, exception.getErrorCode());
+        }
+
+
+
 
 }

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendRequestTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendRequestTest.java
@@ -187,19 +187,6 @@ public class FriendRequestTest {
     }
 
     @Test
-    public void 존재하지_않는_응답자자_ID일_때_예외발생_프로필() {
-        // given
-        Long invalidReceiverId = 99L; // 실제 존재하지 않는 ID
-
-        // when & then
-        FriendException exception = assertThrows(FriendException.class, () ->
-                friendService.sendProfileFriendRequest(requester.getId(), invalidReceiverId)
-        );
-
-        assertEquals(FriendErrorCode.INVALID_MEMBER_ID, exception.getErrorCode());
-    }
-
-    @Test
     public void 본인_계정에_프로필_친구_요청_예외() throws Exception {
         //given
         friendService.sendProfileFriendRequest(requester.getId(), receiver.getId());


### PR DESCRIPTION
## 📌 개요
- 다른 사용자의 프로필에서 친구 요청을 보낼 수 있는 기능을 구현했습니다
- 
## 🛠️ 작업 내용
- 프로필에서 친구 요청 보내기API 작성(`requestProfileFriend`)
- 프로필에서 친구 요청 보내기 서비스 로직 작성(`sendProfileFriendRequest`) 
- 예외 사항 추가(`INVALID_MEMBER_ID`,`REQUEST_ALREADY_RECEIVED`)
- 테스트 코드 작성

### 📌 프로필 친구 요청 API
- 프로필의 친구 요청에서 친구 요청을 보낼 수 있습니다
- 요청시 `Friend` 엔티티 상태는 `REQUEST`로 변경됩니다.


## 📌 차후 계획 (Optional)
- 추후에 `requestProfileFriend` url (/members/from-profile/{recevierId} 로 변경 예정
- 추후에 `INVALID_MEMBER_ID` 예외 사항 (MemberErrorCode로 변경 예정
- 친구 목록 기능 구현 예정
- 친구 삭제 기능 구현 에정

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수 확인
- 기존 테스트 통과 
- 프로필 친구 요청 정상 작동
- 존재하지 않는 요청자 Id에 대해 예외 발생
- 자신의 계정에 대한 친구 요청 예외 발생
- 이미 친구 상태에 대한 친구 요청 예외 발생
- 중복 친구 요청에 대해 예외 발생
- 받은 친구 요청에 대해 예외 발생

Closes #100 