### PR TITLE
[Feature] 스터디 그룹 댓글 작성 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupCommentController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupCommentController.java
@@ -1,0 +1,35 @@
+package com.samsamhajo.deepground.studyGroup.controller;
+
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.global.utils.GlobalLogger;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCommentRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCommentResponse;
+import com.samsamhajo.deepground.studyGroup.service.StudyGroupCommentService;
+import com.samsamhajo.deepground.studyGroup.success.StudyGroupSuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-group/comments")
+public class StudyGroupCommentController {
+
+  private final StudyGroupCommentService commentService;
+
+  @PostMapping
+  public ResponseEntity<SuccessResponse<StudyGroupCommentResponse>> writeComment(
+      @RequestBody @Valid StudyGroupCommentRequest request,
+      @RequestAttribute("member") Member member
+  ) {
+    GlobalLogger.info("스터디 댓글 작성 요청", member.getEmail(), request.getStudyGroupId());
+
+    StudyGroupCommentResponse response = commentService.writeComment(request, member.getId());
+
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.COMMENT_CREATE_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.COMMENT_CREATE_SUCCESS, response));
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCommentRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCommentRequest.java
@@ -1,0 +1,20 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupCommentRequest {
+  @NotNull(message = "스터디 그룹 ID는 필수입니다.")
+  private Long studyGroupId;
+
+  @NotBlank(message = "댓글 내용은 비어 있을 수 없습니다.")
+  private String content;
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCommentResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCommentResponse.java
@@ -1,0 +1,16 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupCommentResponse {
+  private Long commentId;
+  private String writerNickname;
+  private String content;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCommentResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCommentResponse.java
@@ -1,16 +1,24 @@
 package com.samsamhajo.deepground.studyGroup.dto;
 
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
 import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudyGroupCommentResponse {
   private Long commentId;
   private String writerNickname;
   private String content;
   private LocalDateTime createdAt;
+
+  public static StudyGroupCommentResponse from(Long commentId, String writerNickname,
+      String content, LocalDateTime createdAt) {
+    return StudyGroupCommentResponse.builder()
+        .commentId(commentId)
+        .writerNickname(writerNickname)
+        .content(content)
+        .createdAt(createdAt).build();
+  }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupCommentRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupCommentRepository.java
@@ -1,0 +1,7 @@
+package com.samsamhajo.deepground.studyGroup.repository;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyGroupCommentRepository extends JpaRepository<StudyGroupComment, Long> {
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupCommentService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupCommentService.java
@@ -32,7 +32,7 @@ public class StudyGroupCommentService {
     StudyGroupComment comment = StudyGroupComment.of(studyGroup, member, requestDto.getContent());
     StudyGroupComment saved = commentRepository.save(comment);
 
-    return new StudyGroupCommentResponse(
+    return StudyGroupCommentResponse.from(
         saved.getId(),
         member.getNickname(),
         saved.getContent(),

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupCommentService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupCommentService.java
@@ -1,0 +1,42 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCommentRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCommentResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupCommentRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupCommentService {
+
+  private final StudyGroupCommentRepository commentRepository;
+  private final StudyGroupRepository studyGroupRepository;
+  private final MemberRepository memberRepository;
+
+  @Transactional
+  public StudyGroupCommentResponse writeComment(StudyGroupCommentRequest requestDto, Long memberId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+    StudyGroup studyGroup = studyGroupRepository.findById(requestDto.getStudyGroupId())
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디 그룹입니다."));
+
+    StudyGroupComment comment = StudyGroupComment.of(studyGroup, member, requestDto.getContent());
+    StudyGroupComment saved = commentRepository.save(comment);
+
+    return new StudyGroupCommentResponse(
+        saved.getId(),
+        member.getNickname(),
+        saved.getContent(),
+        saved.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/success/StudyGroupSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/success/StudyGroupSuccessCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum StudyGroupSuccessCode implements SuccessCode {
   CREATE_SUCCESS(HttpStatus.CREATED, "스터디 그룹이 성공적으로 생성되었습니다."),
   READ_SUCCESS(HttpStatus.OK, "스터디 그룹 상세 조회 성공"),
-  SEARCH_SUCCESS(HttpStatus.FOUND, "스터디 그룹 조회 성공");
+  SEARCH_SUCCESS(HttpStatus.FOUND, "스터디 그룹 조회 성공"),
+  COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "스터디 댓글이 작성되었습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupCommentServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupCommentServiceTest.java
@@ -1,0 +1,118 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCommentRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCommentResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupCommentRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Transactional
+class StudyGroupCommentServiceTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupCommentService commentService;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private StudyGroupCommentRepository commentRepository;
+
+  @PersistenceContext
+  private EntityManager em;
+
+  private Long memberId;
+  private Long studyGroupId;
+
+  @BeforeEach
+  void setUp() {
+    Member member = Member.createLocalMember("user@test.com", "1234", "댓글작성자");
+    memberRepository.save(member);
+    this.memberId = member.getId();
+
+    StudyGroup group = StudyGroup.of(
+        null, "댓글 테스트 스터디", "설명",
+        LocalDate.now().plusDays(1),
+        LocalDate.now().plusDays(10),
+        LocalDate.now(),
+        LocalDate.now().plusDays(5),
+        10,
+        member,
+        true,
+        "신촌"
+    );
+    studyGroupRepository.save(group);
+    this.studyGroupId = group.getId();
+
+    em.flush();
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("유효한 요청이면 댓글이 저장되고 응답된다")
+  void writeComment_success() {
+    // given
+    StudyGroupCommentRequest request = StudyGroupCommentRequest.builder()
+        .studyGroupId(studyGroupId)
+        .content("이 스터디 괜찮네요!")
+        .build();
+
+    // when
+    StudyGroupCommentResponse response = commentService.writeComment(request, memberId);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getCommentId()).isNotNull();
+    assertThat(response.getContent()).isEqualTo("이 스터디 괜찮네요!");
+    assertThat(response.getWriterNickname()).isEqualTo("댓글작성자");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자로 댓글 작성 시 예외 발생")
+  void writeComment_invalidMember() {
+    // given
+    Long invalidMemberId = -1L;
+    StudyGroupCommentRequest request = StudyGroupCommentRequest.builder()
+        .studyGroupId(studyGroupId)
+        .content("내용")
+        .build();
+
+    // expect
+    assertThatThrownBy(() -> commentService.writeComment(request, invalidMemberId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("존재하지 않는 사용자입니다.");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 스터디로 댓글 작성 시 예외 발생")
+  void writeComment_invalidStudyGroup() {
+    // given
+    Long invalidGroupId = -999L;
+    StudyGroupCommentRequest request = StudyGroupCommentRequest.builder()
+        .studyGroupId(invalidGroupId)
+        .content("내용")
+        .build();
+
+    // expect
+    assertThatThrownBy(() -> commentService.writeComment(request, memberId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("존재하지 않는 스터디 그룹입니다.");
+  }
+}


### PR DESCRIPTION
## 📌 개요

- 스터디 그룹 상세 페이지에서 인증된 사용자가 댓글을 작성할 수 있는 기능을 구현했습니다.
- 댓글 저장과 동시에 응답 DTO로 작성자의 닉네임, 작성 내용, 작성 시간이 반환됩니다.
    

---

## 🛠️ 작업 내용

-  `StudyGroupComment` 엔티티 정의 및 관계 매핑
-  댓글 작성 요청/응답 DTO (`StudyGroupCommentRequest`, `StudyGroupCommentResponse`) 구현
-  댓글 작성 서비스 (`StudyGroupCommentService.writeComment`) 구현
-  댓글 작성 API 컨트롤러 (`StudyGroupCommentController.writeComment`) 구현
-  통합 테스트 (`StudyGroupCommentServiceTest`) 작성 및 통과
-  성공 응답 코드 `StudyGroupSuccessCode.COMMENT_CREATE_SUCCESS` 정의

### 🧩 댓글 작성 요청 DTO 및 응답 DTO

- `@NotNull`, `@NotBlank`를 활용한 유효성 검증 포함
- `StudyGroupCommentResponse`는 응답 시 사용자 닉네임, 내용, 생성 시각을 포함
    
---

### 🌐 댓글 작성 API

- 인증된 사용자에 한하여 댓글 작성 가능 (`@RequestAttribute("member")`)
- POST `/study-group/comments`로 요청
- 작성 완료 시 `201 CREATED` 상태와 함께 댓글 정보 응답

---

## 📌 차후 계획 (Optional)

- 댓글 목록 조회 및 삭제/수정 기능 추가 예정
- 스터디 상세 조회 응답에 댓글 목록 포함 예정 (`StudyGroupDetailResponse` 확장)
    
---

## 📌 테스트 케이스

-  기능 정상 동작 확인: 댓글 저장 및 응답 데이터 검증
-  새로운 의존성 없음
-  코드 스타일 및 컨벤션 준수
-  기존 테스트 통과 및 전체 테스트 통합 확인
- 통합 테스트 기반으로 실제 저장 및 조회 동작을 검증함
- 예외 케이스(존재하지 않는 회원, 존재하지 않는 스터디)에 대한 방어 로직 확인
    

---

### 📌 기타 참고 사항

- 서비스 메서드는 트랜잭션 단위로 처리되며, 예외 발생 시 롤백되도록 설계했습니다.
- `@RequestAttribute("member")` 기반 인증이 필수이므로, Security 필터 연동 확인 필요합니다.
- 리뷰 시 `StudyGroupSuccessCode`에 추가된 코드와 응답 구조도 함께 확인 바랍니다.
    

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.

- 기능의 실제 흐름과 동작이 명확하게 구현되어 있는지
- 예외 처리, 인증 연동 등 실제 운영 상황을 고려한 설계가 잘 반영되었는지
- DTO 네이밍, 도메인 구조, 컨벤션이 일관적인지
- 확장성(댓글 목록, 수정/삭제 등)에 대한 고려가 적절히 되어 있는지
    
Closes #109 