### PR TITLE
[Feature] 피드 글 수정하기

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
@@ -43,12 +43,11 @@ public class FeedController {
     
     @PutMapping(value = "/{feedId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse<Feed>> updateFeed(
-            @PathVariable Long feedId,
+            @PathVariable("feedId") Long feedId,
             @ModelAttribute FeedUpdateRequest request) {
-        
-        Feed updatedFeed = feedService.updateFeed(feedId, request, DEV_MEMBER_ID);
+        feedService.updateFeed(feedId, request, DEV_MEMBER_ID);
         
         return ResponseEntity
-                .ok(SuccessResponse.of(FeedSuccessCode.FEED_UPDATED, updatedFeed));
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_UPDATED));
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
@@ -4,6 +4,7 @@ import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.exception.FeedSuccessCode;
 import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
 import com.samsamhajo.deepground.feed.feed.model.FeedListResponse;
+import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
 import com.samsamhajo.deepground.feed.feed.service.FeedService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +39,16 @@ public class FeedController {
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedSuccessCode.FEEDS_RETRIEVED, feeds));
+    }
+    
+    @PutMapping(value = "/{feedId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SuccessResponse<Feed>> updateFeed(
+            @PathVariable Long feedId,
+            @ModelAttribute FeedUpdateRequest request) {
+        
+        Feed updatedFeed = feedService.updateFeed(feedId, request, DEV_MEMBER_ID);
+        
+        return ResponseEntity
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_UPDATED, updatedFeed));
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/entity/Feed.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/entity/Feed.java
@@ -34,4 +34,8 @@ public class Feed extends BaseEntity {
     public static Feed of(String content, Member member) {
         return new Feed(content, member);
     }
+    
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum FeedErrorCode implements ErrorCode {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드를 찾을 수 없습니다."),
     INVALID_FEED_CONTENT(HttpStatus.BAD_REQUEST, "피드 내용이 유효하지 않습니다."),
+    FEED_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "피드 수정 권한이 없습니다."),
+    FEED_MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 미디어를 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/model/FeedUpdateRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/model/FeedUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.samsamhajo.deepground.feed.feed.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FeedUpdateRequest {
+    private String content;
+    private List<MultipartFile> images;
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedMediaRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedMediaRepository.java
@@ -12,6 +12,9 @@ import java.util.List;
 @Repository
 public interface FeedMediaRepository extends JpaRepository<FeedMedia, Long> {
     List<FeedMedia> findAllByFeedId(Long feedId);
+    
+    void deleteAllByFeedId(Long feedId);
+    
     default FeedMedia getById(Long feedMediaId){
         return findById(feedMediaId)
                 .orElseThrow(() -> new MediaException(MediaErrorCode.MEDIA_NOT_FOUND,feedMediaId));

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -24,6 +24,8 @@ public class FeedMediaService {
 
     @Transactional
     public void createFeedMedia(Feed feed, List<MultipartFile> images){
+        if(images == null || images.isEmpty()) return;
+
         feedMediaRepository.saveAll(
                 images.stream()
                         .map(image -> FeedMedia.of(

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -2,6 +2,8 @@ package com.samsamhajo.deepground.feed.feed.service;
 
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.entity.FeedMedia;
+import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
+import com.samsamhajo.deepground.feed.feed.exception.FeedException;
 import com.samsamhajo.deepground.feed.feed.model.FeedMediaResponse;
 import com.samsamhajo.deepground.feed.feed.repository.FeedMediaRepository;
 import com.samsamhajo.deepground.media.MediaUtils;
@@ -20,6 +22,7 @@ public class FeedMediaService {
 
     private final FeedMediaRepository feedMediaRepository;
 
+    @Transactional
     public void createFeedMedia(Feed feed, List<MultipartFile> images){
         feedMediaRepository.saveAll(
                 images.stream()
@@ -40,5 +43,17 @@ public class FeedMediaService {
 
     public List<FeedMedia> findAllByFeed(Feed feed) {
         return feedMediaRepository.findAllByFeedId(feed.getId());
+    }
+    
+    @Transactional
+    public void deleteAllByFeedId(Long feedId) {
+        // 파일 시스템에서 물리적 미디어 파일 삭제
+        List<FeedMedia> mediaList = feedMediaRepository.findAllByFeedId(feedId);
+        for (FeedMedia media : mediaList) {
+            MediaUtils.deleteMedia(media.getMediaUrl());
+        }
+        
+        // DB에서 삭제 (JPA Query Method 사용)
+        feedMediaRepository.deleteAllByFeedId(feedId);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -50,8 +50,7 @@ public class FeedService {
             throw new FeedException(FeedErrorCode.INVALID_FEED_CONTENT);
         }
 
-        Feed feed = feedRepository.findById(feedId)
-                .orElseThrow(() -> new FeedException(FeedErrorCode.FEED_NOT_FOUND));
+        Feed feed = feedRepository.getById(feedId);
 
         // TODO: 권한 체크 로직 추가 (본인 피드만 수정 가능)
         // if (!feed.getMember().getId().equals(memberId)) {

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -7,6 +7,7 @@ import com.samsamhajo.deepground.feed.feed.exception.FeedException;
 import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
 import com.samsamhajo.deepground.feed.feed.model.FeedListResponse;
 import com.samsamhajo.deepground.feed.feed.model.FeedResponse;
+import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -43,6 +44,29 @@ public class FeedService {
         return feed;
     }
 
+    @Transactional
+    public Feed updateFeed(Long feedId, FeedUpdateRequest request, Long memberId) {
+        if (!StringUtils.hasText(request.getContent())) {
+            throw new FeedException(FeedErrorCode.INVALID_FEED_CONTENT);
+        }
+
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedException(FeedErrorCode.FEED_NOT_FOUND));
+
+        // TODO: 권한 체크 로직 추가 (본인 피드만 수정 가능)
+        // if (!feed.getMember().getId().equals(memberId)) {
+        //     throw new FeedException(FeedErrorCode.FEED_UPDATE_PERMISSION_DENIED);
+        // }
+
+        // 피드 내용 업데이트
+        feed.updateContent(request.getContent());
+
+        // 미디어 업데이트
+        updateFeedMedia(feed, request);
+
+        return feed;
+    }
+
 
     public FeedListResponse getFeeds(Pageable pageable) {
         Page<Feed> feedPages = feedRepository.findAll(pageable);
@@ -67,5 +91,15 @@ public class FeedService {
 
     private void saveFeedMedia(FeedCreateRequest request, Feed feed) {
         feedMediaService.createFeedMedia(feed, request.getImages());
+    }
+    
+    private void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
+        // 피드에 연결된 모든 미디어 삭제
+        feedMediaService.deleteAllByFeedId(feed.getId());
+        
+        // 새 미디어 추가
+        if (request.getImages() != null && !request.getImages().isEmpty()) {
+            feedMediaService.createFeedMedia(feed, request.getImages());
+        }
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/media/MediaUtils.java
+++ b/src/main/java/com/samsamhajo/deepground/media/MediaUtils.java
@@ -71,6 +71,15 @@ public class MediaUtils {
         return name.substring(name.lastIndexOf(".") + 1);
     }
 
+    public static boolean deleteMedia(String mediaUrl) {
+        String[] mediaUrlParts = mediaUrl.split("/");
+        String mediaName = mediaUrlParts[mediaUrlParts.length - 1];
+        String mediaPath = "/media/" + mediaName;
+
+        File file = new File(mediaPath);
+        return file.exists() && file.delete();
+    }
+
     private static String generateRandomString(int length) {
         StringBuilder sb = new StringBuilder();
         String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";


### PR DESCRIPTION
## 📌 개요
피드 글 수정하기 기능입니다.

## 🛠️ 작업 내용
- [ ] 수정 시 기존 Feed의 content 수정 및 연관된 피드 미디어 삭제, 피드 미디어가 새로 생성되도록 수정
- [ ] `MediaUtils`에 물리적으로 미디어 파일을 삭제하는 `deleteMedia` 구현
- [ ] 피드Id로 모든 피드 미디어를 삭제하는 `deleteAllByFeedId`구현


## 📌 차후 계획 (Optional)
피드를 수정합니다. 기존 피드의 content를 수정하고 연관된 모든 피드 미디어를 삭제합니다. 이후 새로운 피드 미디어가 생성되도록 로직을 작성하였습니다.

## 📌 테스트 결과
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/90a46a5b-1b58-4f29-a4d0-46b72984713c" />
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/5e98e7f2-86f5-438f-adb5-20165c082d38" />


## 📌 테스트 케이스
- 기능 정상 동작 확인
- 코드 스타일 및 컨벤션 준수 확인
- 기존 테스트 통과 여부 확인
- 피드 글 수정 테스트 

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
미디어 관련 수정 로직을 처음 작성해보아서, 보다 효율적인 수정 로직이 있다면 말씀 부탁드립니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
closes #70 