### PR TITLE
[Refactor] 캘린더 도메인 리팩토링 및 MemberStudySchedule 파일 추가

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/controller/MemberStudyScheduleController.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/controller/MemberStudyScheduleController.java
@@ -1,0 +1,11 @@
+package com.samsamhajo.deepground.calendar.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/calendar/my-schedules")
+@RequiredArgsConstructor
+public class MemberStudyScheduleController {
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberStudyScheduleRequestDto.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberStudyScheduleRequestDto.java
@@ -1,0 +1,14 @@
+package com.samsamhajo.deepground.calendar.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class MemberStudyScheduleRequestDto {
+
+    private Boolean isAvailable;
+    private Boolean isImportant;
+    private String memo;
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberStudyScheduleResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberStudyScheduleResponseDto.java
@@ -1,0 +1,14 @@
+package com.samsamhajo.deepground.calendar.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberStudyScheduleResponseDto {
+
+    private Long id;
+    private Boolean isAvailable;
+    private Boolean isImportant;
+    private String memo;
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/dto/StudyScheduleResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/dto/StudyScheduleResponseDto.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.calendar.dto;
 
+import com.samsamhajo.deepground.calendar.entity.StudySchedule;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,5 +16,16 @@ public class StudyScheduleResponseDto {
     private LocalDateTime endTime;
     private String description;
     private String location;
+
+    public static StudyScheduleResponseDto from(StudySchedule schedule) {
+        return StudyScheduleResponseDto.builder()
+                .id(schedule.getId())
+                .title(schedule.getTitle())
+                .startTime(schedule.getStartTime())
+                .endTime(schedule.getEndTime())
+                .description(schedule.getDescription())
+                .location(schedule.getLocation())
+                .build();
+    }
 
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
@@ -1,12 +1,11 @@
 package com.samsamhajo.deepground.calendar.repository;
 
 import com.samsamhajo.deepground.calendar.entity.MemberStudySchedule;
-import com.samsamhajo.deepground.calendar.entity.StudySchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberStudyScheduleRepository extends JpaRepository<MemberStudySchedule, Long> {
 
-    void deleteAllByStudySchedule(StudySchedule schedule);
+    void deleteAllByStudyScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
@@ -1,0 +1,12 @@
+package com.samsamhajo.deepground.calendar.repository;
+
+import com.samsamhajo.deepground.calendar.entity.MemberStudySchedule;
+import com.samsamhajo.deepground.calendar.entity.StudySchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberStudyScheduleRepository extends JpaRepository<MemberStudySchedule, Long> {
+
+    void deleteAllByStudySchedule(StudySchedule schedule);
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
@@ -1,0 +1,9 @@
+package com.samsamhajo.deepground.calendar.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberStudyScheduleService {
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
@@ -94,7 +94,7 @@ public class StudyScheduleService {
             throw new ScheduleException(ScheduleErrorCode.MISMATCHED_GROUP);
         }
 
-        memberStudyScheduleRepository.deleteAllByStudySchedule(schedule);
+        memberStudyScheduleRepository.deleteAllByStudyScheduleId(schedule.getId());
 
         studyScheduleRepository.delete(schedule);
     }

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
@@ -5,6 +5,7 @@ import com.samsamhajo.deepground.calendar.dto.StudyScheduleResponseDto;
 import com.samsamhajo.deepground.calendar.entity.StudySchedule;
 import com.samsamhajo.deepground.calendar.exception.ScheduleErrorCode;
 import com.samsamhajo.deepground.calendar.exception.ScheduleException;
+import com.samsamhajo.deepground.calendar.repository.MemberStudyScheduleRepository;
 import com.samsamhajo.deepground.calendar.repository.StudyScheduleRepository;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
@@ -20,6 +21,7 @@ public class StudyScheduleService {
 
     private final StudyScheduleRepository studyScheduleRepository;
     private final StudyGroupRepository studyGroupRepository;
+    private final MemberStudyScheduleRepository memberStudyScheduleRepository;
 
     @Transactional
     public StudyScheduleResponseDto createStudySchedule(Long studyGroupId, StudyScheduleRequestDto requestDto) {
@@ -38,15 +40,7 @@ public class StudyScheduleService {
 
         StudySchedule savedSchedule = studyScheduleRepository.save(studySchedule);
 
-        return StudyScheduleResponseDto.builder()
-                .id(savedSchedule.getId())
-                .title(savedSchedule.getTitle())
-                .startTime(savedSchedule.getStartTime())
-                .endTime(savedSchedule.getEndTime())
-                .description(savedSchedule.getDescription())
-                .location(savedSchedule.getLocation())
-                .build();
-
+        return StudyScheduleResponseDto.from(savedSchedule);
     }
 
     @Transactional(readOnly = true)
@@ -57,15 +51,8 @@ public class StudyScheduleService {
         List<StudySchedule> schedules = studyScheduleRepository.findAllByStudyGroupId(studyGroupId);
 
         return schedules.stream()
-                .map(schedule -> StudyScheduleResponseDto.builder()
-                        .id(schedule.getId())
-                        .title(schedule.getTitle())
-                        .startTime(schedule.getStartTime())
-                        .endTime(schedule.getEndTime())
-                        .description(schedule.getDescription())
-                        .location(schedule.getLocation())
-                        .build()
-                ).toList();
+                .map(StudyScheduleResponseDto::from)
+                .toList();
     }
 
     @Transactional
@@ -95,24 +82,19 @@ public class StudyScheduleService {
                 requestDto.getLocation()
         );
 
-        return StudyScheduleResponseDto.builder()
-                .id(studySchedule.getId())
-                .title(studySchedule.getTitle())
-                .startTime(studySchedule.getStartTime())
-                .endTime(studySchedule.getEndTime())
-                .description(studySchedule.getDescription())
-                .location(studySchedule.getLocation())
-                .build();
+        return StudyScheduleResponseDto.from(studySchedule);
     }
 
     @Transactional
     public void deleteStudySchedule(Long studyGroupId, Long scheduleId) {
         StudySchedule schedule = studyScheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.STUDY_GROUP_NOT_FOUND));
+                .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
 
         if (!schedule.getStudyGroup().getId().equals(studyGroupId)) {
             throw new ScheduleException(ScheduleErrorCode.MISMATCHED_GROUP);
         }
+
+        memberStudyScheduleRepository.deleteAllByStudySchedule(schedule);
 
         studyScheduleRepository.delete(schedule);
     }

--- a/src/test/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleServiceTest.java
@@ -1,0 +1,8 @@
+package com.samsamhajo.deepground.calendar.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberStudyScheduleServiceTest {
+}

--- a/src/test/java/com/samsamhajo/deepground/calendar/service/StudyScheduleServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/calendar/service/StudyScheduleServiceTest.java
@@ -5,6 +5,7 @@ import com.samsamhajo.deepground.calendar.dto.StudyScheduleResponseDto;
 import com.samsamhajo.deepground.calendar.entity.StudySchedule;
 import com.samsamhajo.deepground.calendar.exception.ScheduleErrorCode;
 import com.samsamhajo.deepground.calendar.exception.ScheduleException;
+import com.samsamhajo.deepground.calendar.repository.MemberStudyScheduleRepository;
 import com.samsamhajo.deepground.calendar.repository.StudyScheduleRepository;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
@@ -34,6 +35,9 @@ class StudyScheduleServiceTest {
 
     @Mock
     private StudyGroupRepository studyGroupRepository;
+
+    @Mock
+    private MemberStudyScheduleRepository memberStudyScheduleRepository;
 
     @InjectMocks
     private StudyScheduleService studyScheduleService;
@@ -328,6 +332,7 @@ class StudyScheduleServiceTest {
         studyScheduleService.deleteStudySchedule(studyGroupId, scheduleId);
 
         // then
+        verify(memberStudyScheduleRepository).deleteAllByStudySchedule(schedule);
         verify(studyScheduleRepository).delete(schedule);
     }
 

--- a/src/test/java/com/samsamhajo/deepground/calendar/service/StudyScheduleServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/calendar/service/StudyScheduleServiceTest.java
@@ -332,7 +332,7 @@ class StudyScheduleServiceTest {
         studyScheduleService.deleteStudySchedule(studyGroupId, scheduleId);
 
         // then
-        verify(memberStudyScheduleRepository).deleteAllByStudySchedule(schedule);
+        verify(memberStudyScheduleRepository).deleteAllByStudyScheduleId(schedule.getId());
         verify(studyScheduleRepository).delete(schedule);
     }
 


### PR DESCRIPTION
## 📌 개요

* StudySchedule 삭제 로직 리팩토링 및 관련된 MemberStudySchedule 연동 삭제 처리

* 서비스단 DTO 빌더 패턴을 정적 팩토리 메서드 방식으로 개선


## 🛠️ 작업 내용
- StudySchedule 존재하지 않을 때 SCHEDULE_NOT_FOUND 사용하도록 수정

- StudySchedule 삭제 시 연관된 MemberStudySchedule도 함께 삭제되도록 서비스 로직 및 테스트 코드 수정

- 반복적인 DTO 빌더 호출을 정적 팩토리 메서드(from)로 리팩토링

 - MemberStudySchedule 관련 파일 추가


## 📌 차후 계획 (Optional)

* MemberStudySchedule 관련 기능 확장 예정


## 📌 테스트 케이스
- 기능 정상 동작 확인
- 스터디 일정 삭제 시 관련 MemberStudySchedule 함께 삭제되는지 검증
- StudySchedule이 존재하지 않을 때 SCHEDULE_NOT_FOUND 예외 발생 확인
-  빌더 방식 → 정적 팩토리 메서드 전환 후 응답 DTO 값 정상 매핑 여부 확인

### 📌 기타 참고 사항
- MemberStudySchedule은 양방향 매핑 없이 수동 삭제 방식으로 처리했습니다.

---
closes #196 