### PR TITLE
[Feature] WebSocket 연결 시 JWT 기반 인증

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/auth/jwt/WebSocketInterceptor.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/jwt/WebSocketInterceptor.java
@@ -1,0 +1,67 @@
+package com.samsamhajo.deepground.auth.jwt;
+
+import com.samsamhajo.deepground.auth.security.CustomUserDetailsService;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketInterceptor implements ChannelInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService userDetailsService;
+    private final MemberRepository memberRepository;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null) {
+            return message;
+        }
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            connect(accessor);
+        }
+        return message;
+    }
+
+    private void connect(StompHeaderAccessor accessor) {
+        String jwt = resolveToken(accessor);
+
+        if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
+            Long memberId = jwtProvider.getMemberId(jwt);
+            Member member = memberRepository.findById(memberId).orElse(null);
+            if (member != null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(member.getEmail());
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities()
+                );
+                accessor.setUser(authentication);
+            }
+        }
+    }
+
+    private String resolveToken(StompHeaderAccessor accessor) {
+        String bearerToken = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/controller/ChatMessageController.java
@@ -1,11 +1,13 @@
 package com.samsamhajo.deepground.chat.controller;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.chat.dto.ChatMessageRequest;
 import com.samsamhajo.deepground.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -18,10 +20,10 @@ public class ChatMessageController {
     @MessageMapping("/message")
     public void message(
             @DestinationVariable Long chatRoomId,
-            @Payload ChatMessageRequest request
-            // TODO: @AuthenticationPrincipal UserDetails userDetails
+            @Payload ChatMessageRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        // Long memberId = userDetails.getMemberId();
-        chatMessageService.sendMessage(chatRoomId, request.getSenderId(), request);
+        Long memberId = userDetails.getMember().getId();
+        chatMessageService.sendMessage(chatRoomId, memberId, request);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/chat/dto/ChatMessageRequest.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 @Builder
 public class ChatMessageRequest {
 
-    private Long senderId; // TODO: @AuthenticationPrincipal 사용 시 senderId 제거
     private String message;
     private List<String> mediaIds;
 }

--- a/src/main/java/com/samsamhajo/deepground/global/config/SecurityConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
             "/webjars/**",
             "/v3/api-docs.yaml",
             "/auth/**",
+            "/ws/**",
             "/**"
     };
 

--- a/src/main/java/com/samsamhajo/deepground/global/config/WebSocketConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package com.samsamhajo.deepground.global.config;
 
+import com.samsamhajo.deepground.auth.jwt.WebSocketInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -8,8 +11,16 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketInterceptor webSocketInterceptor;
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketInterceptor);
+    }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {

--- a/src/main/java/com/samsamhajo/deepground/global/config/WebSocketSecurityConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/WebSocketSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.global.config;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.chat.service.ChatRoomMemberService;
 import com.samsamhajo.deepground.utils.destination.DestinationUtils;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.messaging.access.intercept.MessageAuthorizationContext;
 import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager.Builder;
 
@@ -54,7 +56,10 @@ public class WebSocketSecurityConfig {
                 return new AuthorizationDecision(false);
             }
 
-            Long memberId = Long.valueOf(accessor.getUser().getName());
+            Authentication authentication = (Authentication) accessor.getUser();
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+            Long memberId = userDetails.getMember().getId();
             boolean granted = chatRoomMemberService.isChatRoomMember(chatRoomId, memberId);
             return new AuthorizationDecision(granted);
         };

--- a/src/main/java/com/samsamhajo/deepground/utils/destination/DestinationUtils.java
+++ b/src/main/java/com/samsamhajo/deepground/utils/destination/DestinationUtils.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DestinationUtils {
 
-    private static final Pattern CHATROOM_PATTERN = Pattern.compile("^/(topic/app)/chatrooms/(\\d+)/?.*");
+    private static final Pattern CHATROOM_PATTERN = Pattern.compile("^/(topic|app)/chatrooms/(\\d+)/?.*");
 
     public static Long extractChatRoomId(String destination) {
         Matcher matcher = CHATROOM_PATTERN.matcher(destination);

--- a/src/test/java/com/samsamhajo/deepground/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/chat/service/ChatMessageServiceTest.java
@@ -43,7 +43,6 @@ public class ChatMessageServiceTest {
         // given
         String message = "테스트 채팅 메시지";
         ChatMessageRequest request = ChatMessageRequest.builder()
-                .senderId(memberId)
                 .message(message)
                 .build();
         ChatMessage chatMessage = ChatMessage.of(chatRoomId, memberId, message);
@@ -70,7 +69,6 @@ public class ChatMessageServiceTest {
     void sendMessage_withEmptyContent_throwsException() {
         // given
         ChatMessageRequest request = ChatMessageRequest.builder()
-                .senderId(memberId)
                 .build();
 
         // when & then

--- a/src/test/java/com/samsamhajo/deepground/utils/destination/DestinationUtilsTest.java
+++ b/src/test/java/com/samsamhajo/deepground/utils/destination/DestinationUtilsTest.java
@@ -1,0 +1,41 @@
+package com.samsamhajo.deepground.utils.destination;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DestinationUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "/topic/chatrooms/1/message, 1",
+            "/app/chatrooms/1234/message, 1234",
+    })
+    @DisplayName("유효한 채팅방 목적지에서 chatRoomId를 추출한다")
+    void extractChatRoomId_validDestinations(String destination, Long expectedChatRoomId) {
+        // when
+        Long chatRoomId = DestinationUtils.extractChatRoomId(destination);
+
+        // then
+        assertThat(chatRoomId).isNotNull();
+        assertThat(chatRoomId).isEqualTo(expectedChatRoomId);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/topic/chatrooms/",
+            "/topic/chatrooms/abc/message",
+            "/app/chatrooms/abc/message"
+    })
+    @DisplayName("유효하지 않은 채팅방 목적지에서 null을 반환한다")
+    void extractChatRoomId_invalidDestinations(String destination) {
+        // when
+        Long chatRoomId = DestinationUtils.extractChatRoomId(destination);
+
+        // then
+        assertThat(chatRoomId).isNull();
+    }
+}


### PR DESCRIPTION
## 📌 개요

* WebSocket에서 인증된 사용자 정보를 가져올 수 있습니다.

## 🛠️ 작업 내용
- `WebSocketInterceptor` 구현
- `DestinationUtils` 수정 및 테스트 코드 작성

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 없음
- 코드 스타일 및 컨벤션 준수 확인
- 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
- `JwtAuthenticationFilter`와 `WebSocketInterceptor`에 중복되는 코드가 있습니다.
- 리팩토링할 때 공통 로직을 분리하는 것도 좋을 것 같습니다!

Closes #197