### PR TITLE
[ Feature ] 친구 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendSuccessCode.java
@@ -11,7 +11,8 @@ public enum FriendSuccessCode implements SuccessCode {
     FRIEND_SUCCESS_REFUSAL(HttpStatus.OK,"친구 요청이 거절했습니다" ),
     FRIEND_SUCCESS_ACCEPT(HttpStatus.OK,"친구 요청을 수락했습니다" ),
     FRIEND_SENT_LIST_FOUND(HttpStatus.OK, "요청한 친구 요청 목록을 성공적으로 조회했습니다."),
-    FRIEND_RECEIVE_LIST_FOUND(HttpStatus.OK, "수신한 친구 요청 목록을 성공적으로 조회했습니다.");
+    FRIEND_RECEIVE_LIST_FOUND(HttpStatus.OK, "수신한 친구 요청 목록을 성공적으로 조회했습니다."),
+    FRIEND_SUCCESS_GET_LIST(HttpStatus.OK,"친구 목록을 성공적으로 조회했습니다" );
 
 
     private final HttpStatus status;

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -79,6 +79,13 @@ public class FriendController {
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_REQUEST,friendId));
     }
+
+    @GetMapping
+    public  ResponseEntity<SuccessResponse<List<FriendDto>>> getFriendList(@RequestParam Long memberId){
+        List<FriendDto> friends = friendService.getFriendByMemberId(memberId);
+        return ResponseEntity
+                .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_GET_LIST,friends));
+    }
   
 
 

--- a/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/repository/FriendRepository.java
@@ -27,4 +27,6 @@ public interface FriendRepository extends JpaRepository<Friend,Long> {
     @Query("SELECT f FROM Friend f WHERE f.receiveMember.id = :receiverId AND f.status = 'REQUEST'")
     List<Friend> findReceiveRequests(@Param("receiverId") Long receiverId);
 
+    @Query("SELECT f FROM Friend f WHERE (f.requestMember.id = :memberId OR f.receiveMember.id = :memberId) AND f.status = :status ")
+    List<Friend> findAllByMemberIdAndFriendStatus(Long memberId, FriendStatus status);
 }

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -167,4 +167,19 @@ public class FriendService {
             throw new FriendException(FriendErrorCode.REQUEST_ALREADY_RECEIVED);
         }
     }
+
+    public List<FriendDto> getFriendByMemberId(Long memberId) {
+
+            List<Friend> friends = friendRepository. findAllByMemberIdAndFriendStatus(memberId, FriendStatus.ACCEPT);
+
+        return friends.stream()
+                .map(friend -> {
+                    if (friend.getReceiveMember().getId().equals(memberId)) {
+                        return FriendDto.fromReceived(friend);
+                    } else {
+                        return FriendDto.fromSent(friend);
+                    }
+                })
+                .toList();
+    }
 }

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendsTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendsTest.java
@@ -1,0 +1,74 @@
+package com.samsamhajo.deepground.Friend.FriendService;
+
+import com.samsamhajo.deepground.friend.Dto.FriendDto;
+import com.samsamhajo.deepground.friend.repository.FriendRepository;
+import com.samsamhajo.deepground.friend.service.FriendService;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+public class FriendsTest {
+
+    @Autowired
+    private FriendService friendService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+
+    private Member requester;
+    private Member requester2;
+    private Member requester3;
+    private Member receiver;
+    private Member receiver2;
+
+
+
+    @BeforeEach
+    void setup() {
+        requester = Member.createLocalMember("paka@gamil.com", "pw", "파카");
+        requester2 = Member.createLocalMember("gar@gmail.com", "pw", "가");
+        requester3 = Member.createLocalMember("den@gmail.com", "pw", "든");
+        receiver = Member.createLocalMember("garden@gmail.com", "pw", "가든");
+        receiver2 = Member.createLocalMember("pa@gmail.com","pw","파카");
+
+        memberRepository.save(requester);
+        memberRepository.save(requester2);
+        memberRepository.save(requester3);
+        memberRepository.save(receiver);
+        memberRepository.save(receiver2);
+
+    }
+
+    @Test
+    public void 친구_목록() throws Exception {
+        //given
+        Long friendId = friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
+        Long friendId2 = friendService.sendFriendRequest(requester.getId(), receiver2.getEmail());
+
+        friendService.acceptFriendRequest(friendId, receiver.getId());
+        friendService.acceptFriendRequest(friendId2, receiver2.getId());
+        //when
+        List<FriendDto> friends = friendService.getFriendByMemberId(requester.getId());
+
+        //then
+
+        assertTrue(friends.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver.getNickname())));
+        assertTrue(friends.stream().anyMatch(f -> f.getOtherMemberName().equals(receiver2.getNickname())));
+    }
+
+}


### PR DESCRIPTION
## 📌 개요
친구 목록에 대해서 조회하는 기능을 구현하였습니다

## 🛠️ 작업 내용
- 친구 목록 API 구현( `getFriendList` )
- 친구 목록 서비스 로직 구현 (`getFriendByMemberId`)
- `FriendRepository`에 JPQL쿼리 메서드 추가 (`findAllByMemberIdAndFriendStatus`)
- 성공 읍답 메세지 추가(`FRIEND_SUCCESS_GET_LIST`)
- 테스트 코드 작성

### 📌 친구 목록 API
- 회원이 보낸 친구 요청과 받은 친구 요청 중에서, 친구 상태가 'ACCEPT(수락됨)' 상태인 경우만 필터링하여 친구 목록을 조회합니다.

## 📌 차후 계획 (Optional)
- 친구 목록 및 친구 삭제 기능에 대한 Swagger 테스트 추가 예정

## 📌 테스트 케이스
- 기능 정상 동작
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수
- 기존 테스트 통과 

Close #98 