### PR TITLE
[Feature] 내가 생성한 스터디 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
@@ -83,4 +83,18 @@ public class StudyGroupController {
         .status(StudyGroupSuccessCode.REQUEST_JOIN_SUCCESS.getStatus())
         .body(SuccessResponse.of(StudyGroupSuccessCode.REQUEST_JOIN_SUCCESS));
   }
+
+  @GetMapping("/my/{memberId}")
+  public ResponseEntity<SuccessResponse<?>> getMyStudyGroups(
+      @PathVariable Long memberId
+  ) {
+    GlobalLogger.info("사용자 생성 스터디 목록 조회 요청", memberId);
+
+    var response = studyGroupService.findMyStudyGroups(memberId);
+
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.READ_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.READ_SUCCESS, response));
+  }
+
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupMyListResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupMyListResponse.java
@@ -1,0 +1,28 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupMyListResponse {
+
+  private Long id;
+  private String title;
+  private LocalDate createdAt;
+  private GroupStatus groupStatus;
+
+  public static StudyGroupMyListResponse from(StudyGroup group) {
+    return StudyGroupMyListResponse.builder()
+        .id(group.getId())
+        .title(group.getTitle())
+        .createdAt(group.getCreatedAt().toLocalDate()) // BaseEntity 기반
+        .groupStatus(group.getGroupStatus())
+        .build();
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -1,7 +1,9 @@
 package com.samsamhajo.deepground.studyGroup.repository;
 
+import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -36,4 +38,5 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
       "WHERE sg.id = :id")
   Optional<StudyGroup> findWithMemberAndCommentsById(@Param("id") Long studyGroupId);
 
+  List<StudyGroup> findAllByMember_IdOrderByCreatedAtDesc(Long memberId);
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -1,9 +1,11 @@
 package com.samsamhajo.deepground.studyGroup.service;
 
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupDetailResponse;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupMyListResponse;
 import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupResponse;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupSearchRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import com.samsamhajo.deepground.chat.entity.ChatRoom;
@@ -94,6 +96,15 @@ public class StudyGroupService {
 
     return StudyGroupCreateResponse.from(savedGroup);
   }
+
+  public List<StudyGroupMyListResponse> findMyStudyGroups(Long memberId) {
+    List<StudyGroup> groups = studyGroupRepository.findAllByMember_IdOrderByCreatedAtDesc(memberId);
+
+    return groups.stream()
+        .map(StudyGroupMyListResponse::from)
+        .toList();
+  }
+
 
   private void validateRequest(StudyGroupCreateRequest request) {
     LocalDate now = LocalDate.now();

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceMyListTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceMyListTest.java
@@ -1,0 +1,101 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupMyListResponse;
+import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@Rollback
+@TestPropertySource(properties = {
+    "JWT_SECRET=dGhpcy1pcy1hLXNlY3VyZS10ZXN0LXNlY3JldC1rZXktZm9yLWp3dA=="
+})
+class StudyGroupServiceMyListTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private StudyGroupService studyGroupService;
+
+  private Member creator;
+  private Member otherUser;
+
+  @BeforeEach
+  void setUp() {
+    creator = Member.createLocalMember("creator@test.com", "pw", "생성자");
+    otherUser = Member.createLocalMember("other@test.com", "pw", "다른 사용자");
+    memberRepository.save(creator);
+    memberRepository.save(otherUser);
+
+    IntStream.rangeClosed(1, 10).forEach(i -> {
+      StudyGroup group = StudyGroup.of(
+          null, "스터디 " + i, "설명",
+          LocalDate.now().plusDays(1),
+          LocalDate.now().plusDays(30),
+          LocalDate.now(),
+          LocalDate.now().plusDays(5),
+          5, creator, true, "강남"
+      );
+      if (i > 5) {
+        group.changeGroupStatus(GroupStatus.COMPLETED);
+      }
+      studyGroupRepository.save(group);
+    });
+
+    // 다른 사용자가 만든 스터디도 3개 생성
+    IntStream.rangeClosed(1, 3).forEach(i -> {
+      StudyGroup group = StudyGroup.of(
+          null, "타인 스터디 " + i, "설명",
+          LocalDate.now().plusDays(1),
+          LocalDate.now().plusDays(30),
+          LocalDate.now(),
+          LocalDate.now().plusDays(5),
+          5, otherUser, true, "신촌"
+      );
+      studyGroupRepository.save(group);
+    });
+  }
+
+  @Test
+  @DisplayName("특정 사용자가 생성한 스터디 목록을 최신순으로 조회할 수 있다")
+  void findStudyGroupsByCreator() {
+    List<StudyGroupMyListResponse> results = studyGroupService.findMyStudyGroups(creator.getId());
+
+    assertThat(results).hasSize(10);
+    assertThat(results)
+        .isSortedAccordingTo((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
+    assertThat(results)
+        .allSatisfy(res -> assertThat(res.getTitle()).contains("스터디"));
+  }
+
+  @Test
+  @DisplayName("스터디를 생성하지 않은 사용자는 빈 리스트를 받는다")
+  void returnEmptyListWhenNoStudyGroups() {
+    Member emptyMember = Member.createLocalMember("empty@test.com", "pw", "빈사용자");
+    memberRepository.save(emptyMember);
+
+    List<StudyGroupMyListResponse> results = studyGroupService.findMyStudyGroups(emptyMember.getId());
+
+    assertThat(results).isEmpty();
+  }
+}


### PR DESCRIPTION
## 📌 개요

- 특정 사용자가 생성한 스터디 그룹 목록을 `createdAt` 기준 내림차순으로 조회하는 기능을 구현했습니다.
- 주로 마이페이지 혹은 개인 관리 페이지에서 활용될 수 있는 기능입니다.
   
---

## 🛠️ 작업 내용

-  `StudyGroupRepository`에 `findAllByMember_IdOrderByCreatedAtDesc(Long memberId)` 메서드 추가
-  `StudyGroupService`에 `findMyStudyGroups(Long memberId)` 로직 구현
-  응답 DTO `StudyGroupMyListResponse` 정의
-  API 컨트롤러 `/study-group/my/{memberId}` 엔드포인트 추가
-  통합 테스트 `StudyGroupServiceMyListTest` 작성 (정렬 순서, 빈 목록 처리 포함)
-  테스트 환경용 JWT_SECRET 문제 해결 (`@TestPropertySource` 적용 및 base64 + 256bit key 주입)
    

---

### 📌 서비스 & DTO 계층 구현

|구조|설명|
|:--|:--|
|`StudyGroupMyListResponse`|`title`, `createdAt`, `groupStatus`를 포함한 요약 응답 DTO|
|`StudyGroupService`|`findMyStudyGroups(memberId)`에서 Repository 호출 후 DTO로 변환|

---

### 📌 컨트롤러

```http
GET /study-group/my/{memberId}
```

- 인증 없이 `memberId` 경로 변수 기반 조회
- 추후 인증된 사용자 본인만 접근할 수 있도록 개선 가능

---

### 📌 테스트 케이스

|테스트 시나리오|설명|
|:--|:--|
|`findStudyGroupsByCreator()`|사용자가 만든 스터디 목록 10개가 최신순으로 정렬되는지 검증|
|`returnEmptyListWhenNoStudyGroups()`|스터디를 생성하지 않은 사용자가 요청했을 때 빈 리스트 반환 확인|

```java
@TestPropertySource(properties = {
  "JWT_SECRET=ZHVtbXktc2VjcmV0LWFuZC1zZWN1cmUtbG9uZy1rZXktdGVzdC1iYXNlNjQ="
})
```

---

## 📌 차후 계획 
- 해당 기능은 마이페이지 기능으로 확장 가능성이 있음 (`@RequestAttribute("member")` 기반 인증 처리 예정)
- 이후에는 사용자 본인이 생성한 스터디의 **수정/삭제/상태 변경 API**와 연동될 예정
- JWT 토큰을 통해 memberId를 추출하여 사용할 수 있게 변경후, 적용 예정

---

## 📌 테스트 체크리스트

-  기능 정상 동작 확인
-  `JWT_SECRET` 관련 환경 변수 처리 및 보안 길이 기준 충족
-  코드 스타일 및 네이밍 컨벤션 준수
-  전체 테스트 통과 (`IntegrationTestSupport` 기반 포함)

---

### 📌 기타 참고 사항

- `JWT_SECRET`은 JJWT HMAC-SHA256 요구조건에 따라 Base64로 인코딩된 256bit 이상 키를 사용해야 합니다.
- 기존 ApplicationContext 로딩 에러를 해결하기 위해 `TestPropertySource`를 활용했습니다.
- `StudyGroupMyListResponse`는 필요한 필드만 전달하며, 클라이언트가 목록 기반 뷰에 사용하기 적합합니다.

---

🙏🏻 **리뷰어 확인 요청**

- `StudyGroupRepository`의 쿼리 메서드 명 명확성
- `StudyGroupMyListResponse` 필드 구성 적절성
- 컨트롤러 URL 네이밍 및 인증 설계 방향성
- 테스트 클래스 구조와 시나리오 커버리지

Closes #111