### PR TITLE
[Feature] 내가 참여 중인 스터디 그룹 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
@@ -2,6 +2,7 @@ package com.samsamhajo.deepground.studyGroup.controller;
 
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import com.samsamhajo.deepground.global.utils.GlobalLogger;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupParticipationResponse;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupSearchRequest;
 import com.samsamhajo.deepground.studyGroup.service.StudyGroupJoinService;
 import com.samsamhajo.deepground.studyGroup.service.StudyGroupService;
@@ -12,6 +13,7 @@ import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateResponse;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -82,5 +84,19 @@ public class StudyGroupController {
     return ResponseEntity
         .status(StudyGroupSuccessCode.REQUEST_JOIN_SUCCESS.getStatus())
         .body(SuccessResponse.of(StudyGroupSuccessCode.REQUEST_JOIN_SUCCESS));
+  }
+
+  @GetMapping("/{memberId}/joined")
+  public ResponseEntity<SuccessResponse<List<StudyGroupParticipationResponse>>> getMyParticipatedGroups(
+      @PathVariable Long memberId
+  ) {
+    GlobalLogger.info("참가 중인 스터디 목록 조회", memberId);
+
+    List<StudyGroupParticipationResponse> response =
+        studyGroupService.getStudyGroupsByMember(memberId);
+
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.READ_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.READ_SUCCESS, response));
   }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupParticipationResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupParticipationResponse.java
@@ -1,0 +1,26 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StudyGroupParticipationResponse {
+
+  private Long studyGroupId;
+  private String title;
+  private String createdBy;
+  private LocalDateTime participatedAt;
+
+  public static StudyGroupParticipationResponse from(StudyGroup studyGroup, LocalDateTime participatedAt) {
+    return StudyGroupParticipationResponse.builder()
+        .studyGroupId(studyGroup.getId())
+        .title(studyGroup.getTitle())
+        .createdBy(studyGroup.getMember().getNickname())
+        .participatedAt(participatedAt)
+        .build();
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
@@ -3,6 +3,7 @@ package com.samsamhajo.deepground.studyGroup.repository;
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,4 +13,6 @@ public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMemb
   boolean existsByMemberAndStudyGroup(Member member, StudyGroup studyGroup);
 
   Optional<StudyGroupMember> findByMemberAndStudyGroup(Member member, StudyGroup studyGroup);
+
+  List<StudyGroupMember> findAllByMemberIdAndIsAllowedTrueOrderByStudyGroupCreatedAtDesc(Long memberId);
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -2,6 +2,8 @@ package com.samsamhajo.deepground.studyGroup.repository;
 
 import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -35,5 +37,7 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
       "LEFT JOIN FETCH sg.comments " +
       "WHERE sg.id = :id")
   Optional<StudyGroup> findWithMemberAndCommentsById(@Param("id") Long studyGroupId);
+
+  List<StudyGroupMember> findAllByMemberIdAndIsAllowedTrueOrderByCreatedAtDesc(Long memberId);
 
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -38,6 +38,4 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
       "WHERE sg.id = :id")
   Optional<StudyGroup> findWithMemberAndCommentsById(@Param("id") Long studyGroupId);
 
-  List<StudyGroupMember> findAllByMemberIdAndIsAllowedTrueOrderByCreatedAtDesc(Long memberId);
-
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -1,9 +1,13 @@
 package com.samsamhajo.deepground.studyGroup.service;
 
+import static java.util.stream.Collectors.toList;
+
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupDetailResponse;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupParticipationResponse;
 import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupResponse;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupSearchRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import com.samsamhajo.deepground.chat.entity.ChatRoom;
@@ -94,6 +98,19 @@ public class StudyGroupService {
 
     return StudyGroupCreateResponse.from(savedGroup);
   }
+
+  public List<StudyGroupParticipationResponse> getStudyGroupsByMember(Long memberId) {
+    List<StudyGroupMember> studyGroupMembers =
+        studyGroupMemberRepository.findAllByMemberIdAndIsAllowedTrueOrderByStudyGroupCreatedAtDesc(memberId);
+
+    return studyGroupMembers.stream()
+        .map(member -> StudyGroupParticipationResponse.from(
+            member.getStudyGroup(),
+            member.getCreatedAt()
+        ))
+        .toList();
+  }
+
 
   private void validateRequest(StudyGroupCreateRequest request) {
     LocalDate now = LocalDate.now();

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupParticipationServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupParticipationServiceTest.java
@@ -1,0 +1,100 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupParticipationResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@Rollback
+class StudyGroupParticipationServiceTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private StudyGroupMemberRepository studyGroupMemberRepository;
+
+  @Autowired
+  private StudyGroupService studyGroupService;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  private Member member;
+  private Member creator;
+
+  @BeforeEach
+  void setUp() {
+    member = Member.createLocalMember("user@test.com", "pw", "사용자");
+    creator = Member.createLocalMember("creator@test.com", "pw", "작성자");
+    memberRepository.saveAll(List.of(member, creator));
+
+    IntStream.rangeClosed(1, 5).forEach(i -> {
+      StudyGroup group = StudyGroup.of(
+          null, "참가 스터디 " + i, "설명",
+          LocalDate.now(), LocalDate.now().plusDays(30),
+          LocalDate.now(), LocalDate.now().plusDays(10),
+          5, creator, true, "서울"
+      );
+      studyGroupRepository.save(group);
+
+      StudyGroupMember groupMember = StudyGroupMember.of(member, group, true);
+      studyGroupMemberRepository.save(groupMember);
+    });
+
+    IntStream.rangeClosed(1, 2).forEach(i -> {
+      StudyGroup group = StudyGroup.of(
+          null, "대기 스터디 " + i, "설명",
+          LocalDate.now(), LocalDate.now().plusDays(30),
+          LocalDate.now(), LocalDate.now().plusDays(10),
+          5, creator, true, "서울"
+      );
+      studyGroupRepository.save(group);
+
+      StudyGroupMember groupMember = StudyGroupMember.of(member, group, false); // 수락되지 않은 상태
+      studyGroupMemberRepository.save(groupMember);
+    });
+  }
+
+  @Test
+  @DisplayName("사용자가 수락된(studyGroupMember.isAllowed = true) 스터디 목록만 조회할 수 있다")
+  void findMyParticipatedGroups() {
+    List<StudyGroupParticipationResponse> results =
+        studyGroupService.getStudyGroupsByMember(member.getId());
+
+    assertThat(results).hasSize(5);
+    assertThat(results).allSatisfy(res -> {
+      assertThat(res.getTitle()).contains("참가 스터디");
+      assertThat(res.getCreatedBy()).isEqualTo("작성자");
+    });
+  }
+
+  @Test
+  @DisplayName("스터디에 참가하지 않은 사용자는 빈 리스트를 받는다")
+  void emptyParticipationList() {
+    Member outsider = Member.createLocalMember("empty@test.com", "pw", "외부인");
+    memberRepository.save(outsider);
+
+    List<StudyGroupParticipationResponse> results =
+        studyGroupService.getStudyGroupsByMember(outsider.getId());
+
+    assertThat(results).isEmpty();
+  }
+}


### PR DESCRIPTION
## 📌 개요

- 로그인한 사용자가 **참여 승인된 스터디 그룹 목록**을 조회할 수 있는 기능을 추가했습니다.
- `StudyGroupMember` 엔티티를 기준으로 필터링하여 응답 DTO에 스터디 정보(제목, 생성자, 참여일)를 요약해 제공합니다.

---

## 🛠️ 작업 내용

-  `StudyGroupParticipationResponse` DTO 생성
-  `StudyGroupService` 서비스 클래스 및 참여 목록 조회 메서드 구현
-  `StudyGroupMemberRepository`에 쿼리 메서드 추가
-  `StudyGroupController` 컨트롤러 기능 구현
-  통합 테스트 (`StudyGroupParticipationServiceTest`) 작성

### 🔹 DTO 및 서비스 로직 구현

- `StudyGroupParticipationResponse`를 통해 필요한 정보만 가공해 반환
- 참여 상태가 `isAllowed = true`인 경우만 필터링하여 반환

| 클래스                               | 설명                  |
| --------------------------------- | ------------------- |
| `StudyGroupService`               | 로그인 사용자의 참여 스터디 조회  |
| `StudyGroupParticipationResponse` | 스터디 제목, 작성자, 참여일 요약 |

---

### 🔹 컨트롤러 구현

- `GET /api/v1/{memberId}/joined`
- JWT 기반 인증을 통해 현재 로그인한 사용자 식별
- 서비스 계층 호출을 통해 참여 중인 스터디 목록 반환

```java
@GetMapping("/{memberId}/joined")
public List<StudyGroupParticipationResponse> getMyParticipatedStudyGroups(
    @PathVariable Long memberId
) {
    return studyGroupParticipationService.getStudyGroupsByMember(memberId);
}
```

---

## 📌 차후 계획 (Optional)

- 마이페이지에서 내가 생성한 스터디 / 참가한 스터디를 함께 조회할 수 있도록 통합 API 설계 예정
- 참여 승인/거절 내역까지 포함하는 관리자 기능도 고려

---

## 📌 테스트 케이스

-  정상 참여자에 대한 스터디 그룹 목록 반환 확인
-  수락되지 않은 그룹원은 제외되는지 검증
-  로그인 사용자 기준 필터링 동작 확인
-  기존 테스트 통과 확인
-  코드 스타일 / 네이밍 일관성 검토 완료
    

---

### 📌 기타 참고 사항

- Repository 쿼리 메서드 네이밍 주의 (`StudyGroupMember.isAllowed` 기준 필터 필요)
- 참여 승인 여부(`isAllowed = true`)를 체크하지 않으면 승인되지 않은 스터디까지 노출될 수 있어 주의 필요

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.

- 응답 DTO에 필요한 정보가 누락되지 않았는지 확인해주세요.
- 비즈니스 로직이 서비스 단에 잘 분리되었는지 확인해주세요.
- 컨트롤러 응답 구조와 예외 처리 방식이 일관적인지 확인해주세요.
    
Closes #112 