### PR TITLE
[Feature] 피드 글 삭제하기

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
@@ -27,9 +27,10 @@ public class FeedController {
     public ResponseEntity<SuccessResponse<Feed>> createFeed(
             @ModelAttribute FeedCreateRequest request) {
 
-        Feed feed = feedService.createFeed(request, DEV_MEMBER_ID);
+        feedService.createFeed(request, DEV_MEMBER_ID);
+
         return ResponseEntity
-                .ok(SuccessResponse.of(FeedSuccessCode.FEED_CREATED, feed));
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_CREATED));
     }
 
     @GetMapping

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
@@ -50,4 +50,13 @@ public class FeedController {
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedSuccessCode.FEED_UPDATED));
     }
+
+    @DeleteMapping("/{feedId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteFeed(
+            @PathVariable("feedId") Long feedId) {
+        feedService.deleteFeed(feedId, DEV_MEMBER_ID);
+
+        return ResponseEntity
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_DELETED));
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
@@ -9,6 +9,7 @@ public enum FeedErrorCode implements ErrorCode {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드를 찾을 수 없습니다."),
     INVALID_FEED_CONTENT(HttpStatus.BAD_REQUEST, "피드 내용이 유효하지 않습니다."),
     FEED_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "피드 수정 권한이 없습니다."),
+    FEED_DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "피드 삭제 권한이 없습니다."),
     FEED_MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 미디어를 찾을 수 없습니다."),
 
     ;

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedSuccessCode.java
@@ -9,6 +9,7 @@ public enum FeedSuccessCode implements SuccessCode {
     FEED_CREATED(HttpStatus.CREATED, "피드가 성공적으로 생성되었습니다."),
     FEEDS_RETRIEVED(HttpStatus.OK, "피드 목록이 성공적으로 조회되었습니다."),
     FEED_UPDATED(HttpStatus.OK, "피드가 성공적으로 수정되었습니다."),
+    FEED_DELETED(HttpStatus.OK, "피드가 성공적으로 삭제되었습니다."),
     FEED_MEDIA_UPDATED(HttpStatus.OK, "피드 미디어가 성공적으로 수정되었습니다.")
 
     ;

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -59,7 +59,7 @@ public class FeedMediaService {
         feedMediaRepository.deleteAllByFeedId(feedId);
     }
 
-    private void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
+    public void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
         // 피드에 연결된 모든 미디어 삭제
         deleteAllByFeedId(feed.getId());
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -2,9 +2,8 @@ package com.samsamhajo.deepground.feed.feed.service;
 
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.entity.FeedMedia;
-import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
-import com.samsamhajo.deepground.feed.feed.exception.FeedException;
 import com.samsamhajo.deepground.feed.feed.model.FeedMediaResponse;
+import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
 import com.samsamhajo.deepground.feed.feed.repository.FeedMediaRepository;
 import com.samsamhajo.deepground.media.MediaUtils;
 import lombok.RequiredArgsConstructor;
@@ -58,5 +57,15 @@ public class FeedMediaService {
         
         // DB에서 삭제 (JPA Query Method 사용)
         feedMediaRepository.deleteAllByFeedId(feedId);
+    }
+
+    private void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
+        // 피드에 연결된 모든 미디어 삭제
+        deleteAllByFeedId(feed.getId());
+
+        // 새 미디어 추가
+        if (request.getImages() != null && !request.getImages().isEmpty()) {
+            createFeedMedia(feed, request.getImages());
+        }
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -9,6 +9,10 @@ import com.samsamhajo.deepground.feed.feed.model.FeedListResponse;
 import com.samsamhajo.deepground.feed.feed.model.FeedResponse;
 import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.exception.MemberErrorCode;
+import com.samsamhajo.deepground.member.exception.MemberException;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,7 +29,7 @@ public class FeedService {
 
     private final FeedRepository feedRepository;
     private final FeedMediaService feedMediaService;
-    // TODO: private final MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public Feed createFeed(FeedCreateRequest request, Long memberId) {
@@ -33,10 +37,11 @@ public class FeedService {
             throw new FeedException(FeedErrorCode.INVALID_FEED_CONTENT);
         }
 
-        //  TODO: Member member = memberRepository.getById(memberId);
-        //        Feed feed = Feed.of(request.getContent(), member);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
-        Feed feed = Feed.of(request.getContent(), null);
+        Feed feed = Feed.of(request.getContent(), member);
+
         feedRepository.save(feed);
 
         saveFeedMedia(request, feed);

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -98,11 +98,17 @@ public class FeedService {
     }
 
     @Transactional
-    public void deleteFeed(Long feedId) {
+    public void deleteFeed(Long feedId, Long memberId) {
         Feed feed = feedRepository.getById(feedId);
+        
+        // 권한 체크 - 본인 피드만 삭제 가능
+        if (!feed.getMember().getId().equals(memberId)) {
+            throw new FeedException(FeedErrorCode.FEED_UPDATE_PERMISSION_DENIED);
+        }
+        
         feed.softDelete();
         // TODO: FeedLike SoftDelete
-
+        
         feedMediaService.deleteAllByFeedId(feedId);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -101,11 +101,6 @@ public class FeedService {
     public void deleteFeed(Long feedId, Long memberId) {
         Feed feed = feedRepository.getById(feedId);
         
-        // 권한 체크 - 본인 피드만 삭제 가능
-        if (!feed.getMember().getId().equals(memberId)) {
-            throw new FeedException(FeedErrorCode.FEED_UPDATE_PERMISSION_DENIED);
-        }
-        
         feed.softDelete();
         // TODO: FeedLike SoftDelete
         

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -66,7 +66,7 @@ public class FeedService {
         feed.updateContent(request.getContent());
 
         // 미디어 업데이트
-        updateFeedMedia(feed, request);
+        feedMediaService.updateFeedMedia(feed, request);
 
         return feed;
     }
@@ -96,14 +96,12 @@ public class FeedService {
     private void saveFeedMedia(FeedCreateRequest request, Feed feed) {
         feedMediaService.createFeedMedia(feed, request.getImages());
     }
-    
-    private void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
-        // 피드에 연결된 모든 미디어 삭제
-        feedMediaService.deleteAllByFeedId(feed.getId());
-        
-        // 새 미디어 추가
-        if (request.getImages() != null && !request.getImages().isEmpty()) {
-            feedMediaService.createFeedMedia(feed, request.getImages());
-        }
+
+    @Transactional
+    public void deleteFeed(Long feedId){
+        Feed feed = feedRepository.getById(feedId);
+        feedRepository.delete(feed);
+
+        feedMediaService.deleteAllByFeedId(feedId);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -38,7 +38,7 @@ public class FeedService {
         }
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         Feed feed = Feed.of(request.getContent(), member);
 
@@ -98,9 +98,10 @@ public class FeedService {
     }
 
     @Transactional
-    public void deleteFeed(Long feedId){
+    public void deleteFeed(Long feedId) {
         Feed feed = feedRepository.getById(feedId);
-        feedRepository.delete(feed);
+        feed.softDelete();
+        // TODO: FeedLike SoftDelete
 
         feedMediaService.deleteAllByFeedId(feedId);
     }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -57,11 +57,6 @@ public class FeedService {
 
         Feed feed = feedRepository.getById(feedId);
 
-        // TODO: 권한 체크 로직 추가 (본인 피드만 수정 가능)
-        // if (!feed.getMember().getId().equals(memberId)) {
-        //     throw new FeedException(FeedErrorCode.FEED_UPDATE_PERMISSION_DENIED);
-        // }
-
         // 피드 내용 업데이트
         feed.updateContent(request.getContent());
 

--- a/src/main/java/com/samsamhajo/deepground/media/MediaErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/media/MediaErrorCode.java
@@ -9,6 +9,7 @@ public enum MediaErrorCode implements ErrorCode {
     MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "미디어를 찾을 수 없습니다."),
     MEDIA_NOT_SUPPORTED(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 미디어 타입입니다."),
     MEDIA_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "미디어 저장에 실패했습니다."),
+    MEDIA_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "미디어 삭제에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/samsamhajo/deepground/media/MediaUtils.java
+++ b/src/main/java/com/samsamhajo/deepground/media/MediaUtils.java
@@ -74,10 +74,19 @@ public class MediaUtils {
     public static boolean deleteMedia(String mediaUrl) {
         String[] mediaUrlParts = mediaUrl.split("/");
         String mediaName = mediaUrlParts[mediaUrlParts.length - 1];
-        String mediaPath = "/media/" + mediaName;
+        String mediaPath = MEDIA_DIR + mediaName;
 
         File file = new File(mediaPath);
-        return file.exists() && file.delete();
+        if (!file.exists()) {
+            throw new MediaException(MediaErrorCode.MEDIA_NOT_FOUND);
+        }
+        
+        boolean deleted = file.delete();
+        if (!deleted) {
+            throw new MediaException(MediaErrorCode.MEDIA_NOT_SUPPORTED);
+        }
+        
+        return true;
     }
 
     private static String generateRandomString(int length) {

--- a/src/test/java/com/samsamhajo/deepground/media/MediaUtilsTest.java
+++ b/src/test/java/com/samsamhajo/deepground/media/MediaUtilsTest.java
@@ -13,7 +13,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+
+import java.io.File;
 
 @ExtendWith(MockitoExtension.class)
 class MediaUtilsTest {
@@ -88,5 +89,41 @@ class MediaUtilsTest {
 
         // then
         assertThat(extension).isEqualTo("png");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 미디어 파일 삭제 시 실패한다")
+    void deleteMedia_whenFileNotExists_thenReturnsFalse() {
+        // given
+        String nonExistentMediaUrl = "/media/non-existent-file.jpg";
+
+        // when & then
+        assertThatThrownBy(() -> MediaUtils.deleteMedia(nonExistentMediaUrl))
+                .isInstanceOf(MediaException.class);
+    }
+
+    @Test
+    @DisplayName("미디어 파일 삭제 성공 테스트")
+    void deleteMedia_Success() {
+        // given
+        String testFileName = "test-delete-file.txt";
+        String mediaUrl = "/media/" + testFileName;
+        String fullPath = System.getProperty("user.dir") + mediaUrl;
+        
+        // 테스트 파일 생성
+        try {
+            File testFile = new File(fullPath);
+            testFile.getParentFile().mkdirs();
+            testFile.createNewFile();
+        } catch (Exception e) {
+            throw new RuntimeException("테스트 파일 생성 실패", e);
+        }
+
+        // when
+        boolean result = MediaUtils.deleteMedia(mediaUrl);
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(new File(fullPath).exists()).isFalse();
     }
 } 


### PR DESCRIPTION
## 📌 개요

피드 글 및 피드 미디어 삭제하기 구현

## 🛠️ 작업 내용
- [x] `FeedService`에 `MemberRepository` 의존성 추가(주석 제거)
- [x] `MediaUtils` 물리적 삭제 로직 추가
- [x] 피드 수정하기 권한 확인 로직 제거
- [x] FeedController에서 Feed 객체를 응답으로 반환하는 코드 수정(LazyLoad 관련 문제 해결)
- [x] memberRepository 의존성 추가로 인한 기존 테스트 코드 수정
- [x] 관련 이슈 번호 (#71 )

### 📌  작업 결과

- `media` directory 내 물리적 삭제 여부 확인 완료
- 피드 생성 -> 피드 삭제 순서로 진행하여 각 단계별 데이터 베이스 반영여부 확인 완료
![image](https://github.com/user-attachments/assets/554f42d9-9b76-4fb1-8ae0-fb47c5a64b30)




## 📌 차후 계획 (Optional)

Feed가 삭제되면, Feed와 연관관계를 맺은 엔티티도 삭제되어야 합니다. 
삭제 로직을 구현하기 전에 관련된 엔티티 서비스 로직 구현을 먼저 진행해야 했을 것 같다고 생각했습니다🥲
추후 서비스 로직 추가 시, 피드 삭제 로직에 연관 엔티티도 같이 삭제되도록 구현하겠습니다.


## 📌 테스트 케이스
- [x] 권한 관련 테스트 케이스 삭제
- [x] 피드 미디어 삭제(`FeedServiceTest`) 및 물리적 삭제(`MediaUtilsTest`) 테스트 성공/실패 케이스 정상작동 확인
- [x] 코드 스타일 및 컨벤션 준수 확인 완료
- [x] 기존 테스트 통과 여부 확인 완료

### 📌 기타 참고 사항



#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.