### PR TITLE
[Feature] 피드 글 좋아요 추가/삭제 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
@@ -27,9 +27,10 @@ public class FeedController {
     public ResponseEntity<SuccessResponse<Feed>> createFeed(
             @ModelAttribute FeedCreateRequest request) {
 
-        Feed feed = feedService.createFeed(request, DEV_MEMBER_ID);
+        feedService.createFeed(request, DEV_MEMBER_ID);
+
         return ResponseEntity
-                .ok(SuccessResponse.of(FeedSuccessCode.FEED_CREATED, feed));
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_CREATED));
     }
 
     @GetMapping

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
@@ -50,4 +50,13 @@ public class FeedController {
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedSuccessCode.FEED_UPDATED));
     }
+
+    @DeleteMapping("/{feedId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteFeed(
+            @PathVariable("feedId") Long feedId) {
+        feedService.deleteFeed(feedId, DEV_MEMBER_ID);
+
+        return ResponseEntity
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_DELETED));
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedLikeController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedLikeController.java
@@ -1,0 +1,48 @@
+package com.samsamhajo.deepground.feed.feed.controller;
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.feed.feed.exception.FeedSuccessCode;
+import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
+import com.samsamhajo.deepground.feed.feed.model.FeedListResponse;
+import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
+import com.samsamhajo.deepground.feed.feed.service.FeedLikeService;
+import com.samsamhajo.deepground.feed.feed.service.FeedService;
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/feed")
+@RequiredArgsConstructor
+public class FeedLikeController {
+
+    private final FeedLikeService feedLikeService;
+
+    private final Long DEV_MEMBER_ID = 1L;
+
+    @PostMapping("/{feedId}/like")
+    public ResponseEntity<SuccessResponse<Feed>> createFeedLike(
+            @PathVariable ("feedId") Long feedId){
+
+        feedLikeService.feedLikeIncrease(feedId, DEV_MEMBER_ID);
+
+        return ResponseEntity
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_LIKED));
+    }
+
+    @DeleteMapping("/{feedId}/like")
+    public ResponseEntity<SuccessResponse<Feed>> deleteFeedLike(
+            @PathVariable ("feedId") Long feedId){
+
+        feedLikeService.feedLikeDecrease(feedId, DEV_MEMBER_ID);
+
+        return ResponseEntity
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_UNLIKED));
+    }
+
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
@@ -8,12 +8,10 @@ import org.springframework.http.HttpStatus;
 public enum FeedErrorCode implements ErrorCode {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드를 찾을 수 없습니다."),
     INVALID_FEED_CONTENT(HttpStatus.BAD_REQUEST, "피드 내용이 유효하지 않습니다."),
-    FEED_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "피드 수정 권한이 없습니다."),
-    FEED_DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "피드 삭제 권한이 없습니다."),
     FEED_MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 미디어를 찾을 수 없습니다."),
 
     FEED_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 피드 및 좋아요를 찾을 수 없습니다."),
-    FEED_LIKE_MINUS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "좋아요는 음수가 될 수 없습니다."),
+    FEED_LIKE_MINUS_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "좋아요는 음수가 될 수 없습니다."),
     FEED_LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요가 눌러져 있습니다."),
 
     ;

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
@@ -9,6 +9,7 @@ public enum FeedErrorCode implements ErrorCode {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드를 찾을 수 없습니다."),
     INVALID_FEED_CONTENT(HttpStatus.BAD_REQUEST, "피드 내용이 유효하지 않습니다."),
     FEED_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "피드 수정 권한이 없습니다."),
+    FEED_DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "피드 삭제 권한이 없습니다."),
     FEED_MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 미디어를 찾을 수 없습니다."),
 
     ;

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
@@ -13,6 +13,7 @@ public enum FeedErrorCode implements ErrorCode {
     FEED_MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 미디어를 찾을 수 없습니다."),
 
     FEED_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 피드 및 좋아요를 찾을 수 없습니다."),
+    FEED_LIKE_MINUS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "좋아요는 음수가 될 수 없습니다."),
     FEED_LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요가 눌러져 있습니다."),
 
     ;

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedErrorCode.java
@@ -12,6 +12,9 @@ public enum FeedErrorCode implements ErrorCode {
     FEED_DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "피드 삭제 권한이 없습니다."),
     FEED_MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 미디어를 찾을 수 없습니다."),
 
+    FEED_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 피드 및 좋아요를 찾을 수 없습니다."),
+    FEED_LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요가 눌러져 있습니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedSuccessCode.java
@@ -10,7 +10,9 @@ public enum FeedSuccessCode implements SuccessCode {
     FEEDS_RETRIEVED(HttpStatus.OK, "피드 목록이 성공적으로 조회되었습니다."),
     FEED_UPDATED(HttpStatus.OK, "피드가 성공적으로 수정되었습니다."),
     FEED_DELETED(HttpStatus.OK, "피드가 성공적으로 삭제되었습니다."),
-    FEED_MEDIA_UPDATED(HttpStatus.OK, "피드 미디어가 성공적으로 수정되었습니다.")
+    FEED_MEDIA_UPDATED(HttpStatus.OK, "피드 미디어가 성공적으로 수정되었습니다."),
+    FEED_LIKED(HttpStatus.OK, "피드가 성공적으로 좋아요 되었습니다."),
+    FEED_UNLIKED(HttpStatus.OK, "피드 좋아요가 취소되었습니다."),
 
     ;
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedSuccessCode.java
@@ -9,6 +9,7 @@ public enum FeedSuccessCode implements SuccessCode {
     FEED_CREATED(HttpStatus.CREATED, "피드가 성공적으로 생성되었습니다."),
     FEEDS_RETRIEVED(HttpStatus.OK, "피드 목록이 성공적으로 조회되었습니다."),
     FEED_UPDATED(HttpStatus.OK, "피드가 성공적으로 수정되었습니다."),
+    FEED_DELETED(HttpStatus.OK, "피드가 성공적으로 삭제되었습니다."),
     FEED_MEDIA_UPDATED(HttpStatus.OK, "피드 미디어가 성공적으로 수정되었습니다.")
 
     ;

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedLikeRepository.java
@@ -1,0 +1,28 @@
+package com.samsamhajo.deepground.feed.feed.repository;
+
+import com.samsamhajo.deepground.feed.feed.entity.FeedLike;
+import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
+import com.samsamhajo.deepground.feed.feed.exception.FeedException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@Repository
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+
+    int countByFeedId(Long feedId);
+
+    boolean existsByFeedIdAndMemberId(Long feedId, Long memberId);
+
+    List<FeedLike> findByFeedId(Long feedId);
+
+    Optional<FeedLike> findByFeedIdAndMemberId(Long feed, Long memberId);
+
+    default FeedLike getByFeedIdAndMemberId(Long feedId, Long memberId){
+        return findByFeedIdAndMemberId(feedId, memberId)
+                .orElseThrow(()->new FeedException(FeedErrorCode.FEED_LIKE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
@@ -13,6 +13,7 @@ import com.samsamhajo.deepground.member.exception.MemberException;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class FeedLikeService {
     private final MemberRepository memberRepository;
     private final FeedLikeRepository feedLikeRepository;
 
+    @Transactional
     public void feedLikeIncrease(Long feedId, Long memberId) {
         increaseValidate(feedId, memberId);
 
@@ -34,6 +36,7 @@ public class FeedLikeService {
         feedLikeRepository.save(feedLike);
     }
 
+    @Transactional
     public void feedLikeDecrease(Long feedId, Long memberId) {
         FeedLike feedLike = feedLikeRepository.getByFeedIdAndMemberId(feedId, memberId);
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
@@ -23,7 +23,7 @@ public class FeedLikeService {
     private final FeedLikeRepository feedLikeRepository;
 
     public void feedLikeIncrease(Long feedId, Long memberId) {
-        validate(feedId, memberId);
+        increaseValidate(feedId, memberId);
 
         Feed feed = feedRepository.getById(feedId);
         Member member = memberRepository.findById(memberId)
@@ -34,11 +34,17 @@ public class FeedLikeService {
         feedLikeRepository.save(feedLike);
     }
 
+    public void feedLikeDecrease(Long feedId, Long memberId) {
+        FeedLike feedLike = feedLikeRepository.getByFeedIdAndMemberId(feedId, memberId);
+
+        feedLikeRepository.delete(feedLike);
+    }
+
     public int countFeedLikeByFeedId(Long feedId) {
         return feedLikeRepository.countByFeedId(feedId);
     }
 
-    private void validate(Long feedId, Long memberId) {
+    private void increaseValidate(Long feedId, Long memberId) {
         if (feedLikeRepository.existsByFeedIdAndMemberId(feedId, memberId)) {
             throw new FeedException(FeedErrorCode.FEED_LIKE_ALREADY_EXISTS);
         }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
@@ -1,0 +1,46 @@
+package com.samsamhajo.deepground.feed.feed.service;
+
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.feed.feed.entity.FeedLike;
+import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
+import com.samsamhajo.deepground.feed.feed.exception.FeedException;
+import com.samsamhajo.deepground.feed.feed.repository.FeedLikeRepository;
+import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.exception.MemberErrorCode;
+import com.samsamhajo.deepground.member.exception.MemberException;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeedLikeService {
+
+    private final FeedRepository feedRepository;
+    private final MemberRepository memberRepository;
+    private final FeedLikeRepository feedLikeRepository;
+
+    public void feedLikeIncrease(Long feedId, Long memberId) {
+        validate(feedId, memberId);
+
+        Feed feed = feedRepository.getById(feedId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
+
+        FeedLike feedLike = FeedLike.of(feed, member);
+
+        feedLikeRepository.save(feedLike);
+    }
+
+    public int countFeedLikeByFeedId(Long feedId) {
+        return feedLikeRepository.countByFeedId(feedId);
+    }
+
+    private void validate(Long feedId, Long memberId) {
+        if (feedLikeRepository.existsByFeedIdAndMemberId(feedId, memberId)) {
+            throw new FeedException(FeedErrorCode.FEED_LIKE_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
@@ -38,6 +38,9 @@ public class FeedLikeService {
 
     @Transactional
     public void feedLikeDecrease(Long feedId, Long memberId) {
+        // 이미 0 이거나 음수인 경우 취소하려 할 때, 예외 발생 
+        validateDecrease(feedId);
+
         FeedLike feedLike = feedLikeRepository.getByFeedIdAndMemberId(feedId, memberId);
 
         feedLikeRepository.delete(feedLike);
@@ -45,6 +48,12 @@ public class FeedLikeService {
 
     public int countFeedLikeByFeedId(Long feedId) {
         return feedLikeRepository.countByFeedId(feedId);
+    }
+
+    private void validateDecrease(Long feedId) {
+        if(countFeedLikeByFeedId(feedId) <= 0){
+            throw new FeedException(FeedErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED);
+        }
     }
 
     private void increaseValidate(Long feedId, Long memberId) {

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -59,7 +59,7 @@ public class FeedMediaService {
         feedMediaRepository.deleteAllByFeedId(feedId);
     }
 
-    private void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
+    public void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
         // 피드에 연결된 모든 미디어 삭제
         deleteAllByFeedId(feed.getId());
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -2,9 +2,8 @@ package com.samsamhajo.deepground.feed.feed.service;
 
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.entity.FeedMedia;
-import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
-import com.samsamhajo.deepground.feed.feed.exception.FeedException;
 import com.samsamhajo.deepground.feed.feed.model.FeedMediaResponse;
+import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
 import com.samsamhajo.deepground.feed.feed.repository.FeedMediaRepository;
 import com.samsamhajo.deepground.media.MediaUtils;
 import lombok.RequiredArgsConstructor;
@@ -58,5 +57,15 @@ public class FeedMediaService {
         
         // DB에서 삭제 (JPA Query Method 사용)
         feedMediaRepository.deleteAllByFeedId(feedId);
+    }
+
+    private void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
+        // 피드에 연결된 모든 미디어 삭제
+        deleteAllByFeedId(feed.getId());
+
+        // 새 미디어 추가
+        if (request.getImages() != null && !request.getImages().isEmpty()) {
+            createFeedMedia(feed, request.getImages());
+        }
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -9,6 +9,10 @@ import com.samsamhajo.deepground.feed.feed.model.FeedListResponse;
 import com.samsamhajo.deepground.feed.feed.model.FeedResponse;
 import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.exception.MemberErrorCode;
+import com.samsamhajo.deepground.member.exception.MemberException;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,7 +29,7 @@ public class FeedService {
 
     private final FeedRepository feedRepository;
     private final FeedMediaService feedMediaService;
-    // TODO: private final MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public Feed createFeed(FeedCreateRequest request, Long memberId) {
@@ -33,10 +37,11 @@ public class FeedService {
             throw new FeedException(FeedErrorCode.INVALID_FEED_CONTENT);
         }
 
-        //  TODO: Member member = memberRepository.getById(memberId);
-        //        Feed feed = Feed.of(request.getContent(), member);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
-        Feed feed = Feed.of(request.getContent(), null);
+        Feed feed = Feed.of(request.getContent(), member);
+
         feedRepository.save(feed);
 
         saveFeedMedia(request, feed);

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -98,11 +98,17 @@ public class FeedService {
     }
 
     @Transactional
-    public void deleteFeed(Long feedId) {
+    public void deleteFeed(Long feedId, Long memberId) {
         Feed feed = feedRepository.getById(feedId);
+        
+        // 권한 체크 - 본인 피드만 삭제 가능
+        if (!feed.getMember().getId().equals(memberId)) {
+            throw new FeedException(FeedErrorCode.FEED_UPDATE_PERMISSION_DENIED);
+        }
+        
         feed.softDelete();
         // TODO: FeedLike SoftDelete
-
+        
         feedMediaService.deleteAllByFeedId(feedId);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -101,11 +101,6 @@ public class FeedService {
     public void deleteFeed(Long feedId, Long memberId) {
         Feed feed = feedRepository.getById(feedId);
         
-        // 권한 체크 - 본인 피드만 삭제 가능
-        if (!feed.getMember().getId().equals(memberId)) {
-            throw new FeedException(FeedErrorCode.FEED_UPDATE_PERMISSION_DENIED);
-        }
-        
         feed.softDelete();
         // TODO: FeedLike SoftDelete
         

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -66,7 +66,7 @@ public class FeedService {
         feed.updateContent(request.getContent());
 
         // 미디어 업데이트
-        updateFeedMedia(feed, request);
+        feedMediaService.updateFeedMedia(feed, request);
 
         return feed;
     }
@@ -96,14 +96,12 @@ public class FeedService {
     private void saveFeedMedia(FeedCreateRequest request, Feed feed) {
         feedMediaService.createFeedMedia(feed, request.getImages());
     }
-    
-    private void updateFeedMedia(Feed feed, FeedUpdateRequest request) {
-        // 피드에 연결된 모든 미디어 삭제
-        feedMediaService.deleteAllByFeedId(feed.getId());
-        
-        // 새 미디어 추가
-        if (request.getImages() != null && !request.getImages().isEmpty()) {
-            feedMediaService.createFeedMedia(feed, request.getImages());
-        }
+
+    @Transactional
+    public void deleteFeed(Long feedId){
+        Feed feed = feedRepository.getById(feedId);
+        feedRepository.delete(feed);
+
+        feedMediaService.deleteAllByFeedId(feedId);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -38,7 +38,7 @@ public class FeedService {
         }
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         Feed feed = Feed.of(request.getContent(), member);
 
@@ -98,9 +98,10 @@ public class FeedService {
     }
 
     @Transactional
-    public void deleteFeed(Long feedId){
+    public void deleteFeed(Long feedId) {
         Feed feed = feedRepository.getById(feedId);
-        feedRepository.delete(feed);
+        feed.softDelete();
+        // TODO: FeedLike SoftDelete
 
         feedMediaService.deleteAllByFeedId(feedId);
     }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -57,11 +57,6 @@ public class FeedService {
 
         Feed feed = feedRepository.getById(feedId);
 
-        // TODO: 권한 체크 로직 추가 (본인 피드만 수정 가능)
-        // if (!feed.getMember().getId().equals(memberId)) {
-        //     throw new FeedException(FeedErrorCode.FEED_UPDATE_PERMISSION_DENIED);
-        // }
-
         // 피드 내용 업데이트
         feed.updateContent(request.getContent());
 

--- a/src/main/java/com/samsamhajo/deepground/media/MediaErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/media/MediaErrorCode.java
@@ -9,6 +9,7 @@ public enum MediaErrorCode implements ErrorCode {
     MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "미디어를 찾을 수 없습니다."),
     MEDIA_NOT_SUPPORTED(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 미디어 타입입니다."),
     MEDIA_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "미디어 저장에 실패했습니다."),
+    MEDIA_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "미디어 삭제에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/samsamhajo/deepground/media/MediaUtils.java
+++ b/src/main/java/com/samsamhajo/deepground/media/MediaUtils.java
@@ -74,10 +74,19 @@ public class MediaUtils {
     public static boolean deleteMedia(String mediaUrl) {
         String[] mediaUrlParts = mediaUrl.split("/");
         String mediaName = mediaUrlParts[mediaUrlParts.length - 1];
-        String mediaPath = "/media/" + mediaName;
+        String mediaPath = MEDIA_DIR + mediaName;
 
         File file = new File(mediaPath);
-        return file.exists() && file.delete();
+        if (!file.exists()) {
+            throw new MediaException(MediaErrorCode.MEDIA_NOT_FOUND);
+        }
+        
+        boolean deleted = file.delete();
+        if (!deleted) {
+            throw new MediaException(MediaErrorCode.MEDIA_NOT_SUPPORTED);
+        }
+        
+        return true;
     }
 
     private static String generateRandomString(int length) {

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeServiceTest.java
@@ -1,0 +1,143 @@
+package com.samsamhajo.deepground.feed.feed.service;
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.feed.feed.entity.FeedLike;
+import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
+import com.samsamhajo.deepground.feed.feed.exception.FeedException;
+import com.samsamhajo.deepground.feed.feed.repository.FeedLikeRepository;
+import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.exception.MemberErrorCode;
+import com.samsamhajo.deepground.member.exception.MemberException;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedLikeServiceTest {
+
+    @InjectMocks
+    private FeedLikeService feedLikeService;
+
+    @Mock
+    private FeedRepository feedRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private FeedLikeRepository feedLikeRepository;
+
+    private final Member member = Member.createLocalMember("test@naver.com", "password", "testUser");
+    private final Feed feed = Feed.of("테스트 피드 내용", member);
+
+    @Test
+    @DisplayName("피드 좋아요 증가 성공 테스트")
+    void feedLikeIncrease_Success() {
+        // given
+        Long feedId = 1L;
+        Long memberId = 1L;
+
+        given(feedRepository.getById(feedId)).willReturn(feed);
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(feedLikeRepository.existsByFeedIdAndMemberId(feedId, memberId)).willReturn(false);
+
+        // when
+        feedLikeService.feedLikeIncrease(feedId, memberId);
+
+        // then
+        verify(feedLikeRepository, times(1)).save(any(FeedLike.class));
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 증가 실패 테스트 - 이미 좋아요한 경우")
+    void feedLikeIncrease_Fail_AlreadyLiked() {
+        // given
+        Long feedId = 1L;
+        Long memberId = 1L;
+
+        given(feedLikeRepository.existsByFeedIdAndMemberId(feedId, memberId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.feedLikeIncrease(feedId, memberId))
+                .isInstanceOf(FeedException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_LIKE_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 증가 실패 테스트 - 존재하지 않는 회원")
+    void feedLikeIncrease_Fail_MemberNotFound() {
+        // given
+        Long feedId = 1L;
+        Long nonExistentMemberId = 999L;
+
+        given(feedLikeRepository.existsByFeedIdAndMemberId(feedId, nonExistentMemberId)).willReturn(false);
+        given(memberRepository.findById(nonExistentMemberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.feedLikeIncrease(feedId, nonExistentMemberId))
+                .isInstanceOf(MemberException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 감소 성공 테스트")
+    void feedLikeDecrease_Success() {
+        // given
+        Long feedId = 1L;
+        Long memberId = 1L;
+        FeedLike feedLike = FeedLike.of(feed, member);
+
+        given(feedLikeRepository.countByFeedId(feedId)).willReturn(1);
+        given(feedLikeRepository.getByFeedIdAndMemberId(feedId, memberId)).willReturn(feedLike);
+
+        // when
+        feedLikeService.feedLikeDecrease(feedId, memberId);
+
+        // then
+        verify(feedLikeRepository, times(1)).delete(feedLike);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 감소 실패 테스트 - 좋아요가 없는 경우")
+    void feedLikeDecrease_Fail_NoLikes() {
+        // given
+        Long feedId = 1L;
+        Long memberId = 1L;
+
+        given(feedLikeRepository.countByFeedId(feedId)).willReturn(0);
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.feedLikeDecrease(feedId, memberId))
+                .isInstanceOf(FeedException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 수 조회 테스트")
+    void countFeedLikeByFeedId_Success() {
+        // given
+        Long feedId = 1L;
+        int expectedCount = 5;
+
+        given(feedLikeRepository.countByFeedId(feedId)).willReturn(expectedCount);
+
+        // when
+        int actualCount = feedLikeService.countFeedLikeByFeedId(feedId);
+
+        // then
+        assertThat(actualCount).isEqualTo(expectedCount);
+    }
+} 

--- a/src/test/java/com/samsamhajo/deepground/media/MediaUtilsTest.java
+++ b/src/test/java/com/samsamhajo/deepground/media/MediaUtilsTest.java
@@ -13,7 +13,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+
+import java.io.File;
 
 @ExtendWith(MockitoExtension.class)
 class MediaUtilsTest {
@@ -88,5 +89,41 @@ class MediaUtilsTest {
 
         // then
         assertThat(extension).isEqualTo("png");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 미디어 파일 삭제 시 실패한다")
+    void deleteMedia_whenFileNotExists_thenReturnsFalse() {
+        // given
+        String nonExistentMediaUrl = "/media/non-existent-file.jpg";
+
+        // when & then
+        assertThatThrownBy(() -> MediaUtils.deleteMedia(nonExistentMediaUrl))
+                .isInstanceOf(MediaException.class);
+    }
+
+    @Test
+    @DisplayName("미디어 파일 삭제 성공 테스트")
+    void deleteMedia_Success() {
+        // given
+        String testFileName = "test-delete-file.txt";
+        String mediaUrl = "/media/" + testFileName;
+        String fullPath = System.getProperty("user.dir") + mediaUrl;
+        
+        // 테스트 파일 생성
+        try {
+            File testFile = new File(fullPath);
+            testFile.getParentFile().mkdirs();
+            testFile.createNewFile();
+        } catch (Exception e) {
+            throw new RuntimeException("테스트 파일 생성 실패", e);
+        }
+
+        // when
+        boolean result = MediaUtils.deleteMedia(mediaUrl);
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(new File(fullPath).exists()).isFalse();
     }
 } 


### PR DESCRIPTION
## 📌 개요

피드 글 좋아요 추가 및 삭제 API 구현하였습니다.

## 🛠️ 작업 내용
- [x] `FeedLikeService` : 좋아요 추가,삭제,조회 로직 구현
- [x] 피드 좋아요 추가, 삭제, 조회 테스트 코드 작성
- [x] 관련 이슈 번호 (#73 )

### 작업 결과(피드 글 좋아요 추가)
- 데이터베이스 반영 여부 확인
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/cb8d422a-d165-44c2-89fa-d2cb4db46265" />

### 작업 결과(피드 글 좋아요 삭제)
- 데이터베이스 반영 여부 확인
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/4d032bc9-a54e-4660-aee5-4d6d39ef2de1" />

## 📌 차후 계획 (Optional)
추후 피드 삭제하기 로직이 수행될 경우, 피드 좋아요도 제거되도록 코드 작성하겠습니다.

## 📌 테스트 케이스
- [x] 좋아요 감소 성공/실패 테스트 작성
- [x] 좋아요 증가 성공/실패 테스트 작성
- [x] 좋아요 조회 테스트 작성
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

아쉽거나 부족한 부분이 있다면 리뷰로 말씀 부탁드립니다. 

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.