### PR TITLE
[Feature] 특정 멤버의 전체 일정 조회 API 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/controller/MemberStudyScheduleController.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/controller/MemberStudyScheduleController.java
@@ -1,11 +1,32 @@
 package com.samsamhajo.deepground.calendar.controller;
 
+import com.samsamhajo.deepground.calendar.dto.MemberScheduleCalendarResponseDto;
+import com.samsamhajo.deepground.calendar.exception.ScheduleSuccessCode;
+import com.samsamhajo.deepground.calendar.service.MemberStudyScheduleService;
+import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/calendar/my-schedules")
 @RequiredArgsConstructor
 public class MemberStudyScheduleController {
+
+    private final MemberStudyScheduleService memberStudyScheduleService;
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<SuccessResponse<List<MemberScheduleCalendarResponseDto>>> getMemberStudySchedulesByMemberId(
+            @PathVariable Long memberId
+    ) {
+        List<MemberScheduleCalendarResponseDto> memberStudySchedules = memberStudyScheduleService.findAllByMemberId(memberId);
+
+        return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_FOUND.getStatus())
+                .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_FOUND, memberStudySchedules));
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberScheduleCalendarResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberScheduleCalendarResponseDto.java
@@ -1,0 +1,22 @@
+package com.samsamhajo.deepground.calendar.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MemberScheduleCalendarResponseDto {
+
+    private Long memberStudyScheduleId;
+    private Long studyScheduleId;
+    private String title;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String description;
+    private String location;
+    private Boolean isAvailable;
+    private Boolean isImportant;
+    private String memo;
+}

--- a/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberScheduleCalendarResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberScheduleCalendarResponseDto.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.calendar.dto;
 
+import com.samsamhajo.deepground.calendar.entity.MemberStudySchedule;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,4 +20,20 @@ public class MemberScheduleCalendarResponseDto {
     private Boolean isAvailable;
     private Boolean isImportant;
     private String memo;
+
+    public static MemberScheduleCalendarResponseDto from(MemberStudySchedule schedule) {
+        var ss = schedule.getStudySchedule();
+        return MemberScheduleCalendarResponseDto.builder()
+                .memberStudyScheduleId(schedule.getId())
+                .studyScheduleId(ss.getId())
+                .title(ss.getTitle())
+                .startTime(ss.getStartTime())
+                .endTime(ss.getEndTime())
+                .description(ss.getDescription())
+                .location(ss.getLocation())
+                .isAvailable(schedule.getIsAvailable())
+                .isImportant(schedule.getIsImportant())
+                .memo(schedule.getMemo())
+                .build();
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleErrorCode.java
@@ -13,7 +13,8 @@ public enum ScheduleErrorCode implements ErrorCode {
     MISSING_REQUIRED_FIELDS(HttpStatus.BAD_REQUEST, "필수 입력 값이 누락되었습니다."),
     STUDY_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디 그룹을 찾을 수 없습니다."),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 일정을 찾을 수 없습니다."),
-    MISMATCHED_GROUP(HttpStatus.FORBIDDEN, "해당 스케줄은 요청한 스터디 그룹에 속하지 않습니다.");
+    MISMATCHED_GROUP(HttpStatus.FORBIDDEN, "해당 스케줄은 요청한 스터디 그룹에 속하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
@@ -2,10 +2,17 @@ package com.samsamhajo.deepground.calendar.repository;
 
 import com.samsamhajo.deepground.calendar.entity.MemberStudySchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface MemberStudyScheduleRepository extends JpaRepository<MemberStudySchedule, Long> {
 
     void deleteAllByStudyScheduleId(Long scheduleId);
+
+    @Query("SELECT mss FROM MemberStudySchedule mss JOIN FETCH mss.studySchedule WHERE mss.member.id = :memberId")
+    List<MemberStudySchedule> findAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
@@ -26,21 +26,7 @@ public class MemberStudyScheduleService {
 
         List<MemberStudySchedule> schedules = memberStudyScheduleRepository.findAllByMemberId(memberId);
         return schedules.stream()
-                .map(schedule -> {
-                    var ss = schedule.getStudySchedule(); // StudySchedule 객체 가져오기
-                    return MemberScheduleCalendarResponseDto.builder()
-                            .memberStudyScheduleId(schedule.getId())
-                            .studyScheduleId(ss.getId())
-                            .title(ss.getTitle())
-                            .startTime(ss.getStartTime())
-                            .endTime(ss.getEndTime())
-                            .description(ss.getDescription())
-                            .location(ss.getLocation())
-                            .isAvailable(schedule.getIsAvailable())
-                            .isImportant(schedule.getIsImportant())
-                            .memo(schedule.getMemo())
-                            .build();
-                })
+                .map(MemberScheduleCalendarResponseDto::from)
                 .toList();
     }
 

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
@@ -1,9 +1,52 @@
 package com.samsamhajo.deepground.calendar.service;
 
+import com.samsamhajo.deepground.calendar.dto.MemberScheduleCalendarResponseDto;
+import com.samsamhajo.deepground.calendar.entity.MemberStudySchedule;
+import com.samsamhajo.deepground.calendar.exception.ScheduleErrorCode;
+import com.samsamhajo.deepground.calendar.exception.ScheduleException;
+import com.samsamhajo.deepground.calendar.repository.MemberStudyScheduleRepository;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MemberStudyScheduleService {
+
+    private final MemberRepository memberRepository;
+    private final MemberStudyScheduleRepository memberStudyScheduleRepository;
+
+    @Transactional(readOnly = true)
+    public List<MemberScheduleCalendarResponseDto> findAllByMemberId(Long memberId) {
+
+        validateMember(memberId);
+
+        List<MemberStudySchedule> schedules = memberStudyScheduleRepository.findAllByMemberId(memberId);
+        return schedules.stream()
+                .map(schedule -> {
+                    var ss = schedule.getStudySchedule(); // StudySchedule 객체 가져오기
+                    return MemberScheduleCalendarResponseDto.builder()
+                            .memberStudyScheduleId(schedule.getId())
+                            .studyScheduleId(ss.getId())
+                            .title(ss.getTitle())
+                            .startTime(ss.getStartTime())
+                            .endTime(ss.getEndTime())
+                            .description(ss.getDescription())
+                            .location(ss.getLocation())
+                            .isAvailable(schedule.getIsAvailable())
+                            .isImportant(schedule.getIsImportant())
+                            .memo(schedule.getMemo())
+                            .build();
+                })
+                .toList();
+    }
+
+    private void validateMember(Long memberId) {
+        if (memberRepository.findById(memberId).isEmpty()) {
+            throw new ScheduleException(ScheduleErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
 }

--- a/src/test/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleServiceTest.java
@@ -1,8 +1,93 @@
 package com.samsamhajo.deepground.calendar.service;
 
+import com.samsamhajo.deepground.calendar.dto.MemberScheduleCalendarResponseDto;
+import com.samsamhajo.deepground.calendar.entity.MemberStudySchedule;
+import com.samsamhajo.deepground.calendar.entity.StudySchedule;
+import com.samsamhajo.deepground.calendar.exception.ScheduleErrorCode;
+import com.samsamhajo.deepground.calendar.exception.ScheduleException;
+import com.samsamhajo.deepground.calendar.repository.MemberStudyScheduleRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class MemberStudyScheduleServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberStudyScheduleRepository memberStudyScheduleRepository;
+
+    @InjectMocks
+    private MemberStudyScheduleService memberStudyScheduleService;
+
+    @Test
+    @DisplayName("멤버 ID로 멤버 스터디 일정 조회 성공")
+    void findMemberSchedulesByMemberId_Success() {
+        // given
+        Long memberId = 1L;
+        Long studyScheduleId = 10L;
+        Member member = mock(Member.class);
+        StudySchedule studySchedule = mock(StudySchedule.class);
+
+        // studySchedule mock 설정
+        when(studySchedule.getId()).thenReturn(studyScheduleId);
+        when(studySchedule.getTitle()).thenReturn("스터디 일정 제목");
+        when(studySchedule.getStartTime()).thenReturn(LocalDateTime.of(2025, 5, 30, 14, 0));
+        when(studySchedule.getEndTime()).thenReturn(LocalDateTime.of(2025, 5, 30, 16, 0));
+        when(studySchedule.getDescription()).thenReturn("스터디 일정 설명");
+        when(studySchedule.getLocation()).thenReturn("온라인");
+
+        MemberStudySchedule memberStudySchedule = MemberStudySchedule.of(studySchedule, member, true, true, "memo");
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(memberStudyScheduleRepository.findAllByMemberId(memberId)).thenReturn(List.of(memberStudySchedule));
+
+        // when
+        List<MemberScheduleCalendarResponseDto> result = memberStudyScheduleService.findAllByMemberId(memberId);
+
+        // then
+        assertThat(result.size()).isEqualTo(1);
+        MemberScheduleCalendarResponseDto dto = result.get(0);
+        assertThat(dto.getMemberStudyScheduleId()).isEqualTo(memberStudySchedule.getId());
+        assertThat(dto.getStudyScheduleId()).isEqualTo(studyScheduleId);
+        assertThat(dto.getTitle()).isEqualTo("스터디 일정 제목");
+        assertThat(dto.getStartTime()).isEqualTo(LocalDateTime.of(2025, 5, 30, 14, 0));
+        assertThat(dto.getEndTime()).isEqualTo(LocalDateTime.of(2025, 5, 30, 16, 0));
+        assertThat(dto.getDescription()).isEqualTo("스터디 일정 설명");
+        assertThat(dto.getLocation()).isEqualTo("온라인");
+        assertThat(dto.getIsAvailable()).isTrue();
+        assertThat(dto.getIsImportant()).isTrue();
+        assertThat(dto.getMemo()).isEqualTo("memo");
+    }
+
+    @Test
+    @DisplayName("멤버 스터디 일정 조회 실패 - 존재하지 않는 멤버")
+    void findMemberSchedulesByMemberId_Fail_MemberNotFound() {
+        // given
+        Long memberId = 1L;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberStudyScheduleService.findAllByMemberId(memberId))
+                .isInstanceOf(ScheduleException.class)
+                .hasMessageContaining(ScheduleErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+        verify(memberRepository).findById(memberId);
+        verify(memberStudyScheduleRepository, never()).findAllByMemberId(anyLong());
+    }
 }


### PR DESCRIPTION
## 📌 개요

* 특정 멤버가 자신의 캘린더에 들어갔을 때, 본인의 모든 일정을 확인할 수 있도록 조회 API를 구현했습니다.

## 🛠️ 작업 내용
- MemberStudyScheduleController에 GET API 추가
- MemberStudyScheduleService에 조회 로직 구현
- MemberScheduleCalendarResponseDto 작성
- 서비스 테스트 코드 작성 및 성공/실패 케이스 검증


## 📌 차후 계획 (Optional)

* 현재는 PathVariable로 memberId를 받아 일정 목록을 조회하지만
추후에는 로그인 된 사용자 정보를 기반으로 본인의 일정을 조회하도록 리팩토링할 예정입니다.


## 📌 테스트 케이스
- 멤버 ID로 정상 조회되는 경우
- 존재하지 않는 멤버 ID로 조회 시 예외 발생 (ScheduleException)
- 연관된 StudySchedule의 정보까지 포함되는지 검증


---
closes #89 