### PR TITLE
[Refactor] 친구 프로필에서 친구 요청 및 프로필 수정 시 memberId로 사용자 조회하도록 변경

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -74,8 +74,8 @@ public class FriendController {
 
     @PostMapping("/from-profile/{receiverId}")
     public ResponseEntity<SuccessResponse> requestProfileFriend(@PathVariable Long receiverId,
-                                                                @AuthenticationPrincipal Member requester) {
-        Long friendId = friendService.sendProfileFriendRequest(requester.getId(), receiverId);
+                                                                @RequestParam Long memberId) {
+        Long friendId = friendService.sendProfileFriendRequest(memberId, receiverId);
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_REQUEST,friendId));
     }

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -137,9 +137,9 @@ public class FriendService {
     }
 
     @Transactional
-    public Long sendProfileFriendRequest(Long requesterId, Long receiverId) {
+    public Long sendProfileFriendRequest(Long memberId, Long receiverId) {
 
-        Member requester = memberRepository.findById(requesterId)
+        Member requester = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         Member receiver = memberRepository.findById(receiverId)

--- a/src/main/java/com/samsamhajo/deepground/member/Dto/MemberProfileDto.java
+++ b/src/main/java/com/samsamhajo/deepground/member/Dto/MemberProfileDto.java
@@ -29,7 +29,7 @@ public class MemberProfileDto {
     @NotBlank (message = "사는 지역을 입력해주세요")
     private String liveIn;
     private String education;
-    @NotBlank (message = "기술 스택을 입력해주세요")
+    @NotNull (message = "한가지 이상의 기술 스택을 입력해주세요")
     private List<String> techStack ;
     @URL(message = "올바른 URL 형식이 아닙니다.")
     private String githubUrl;

--- a/src/main/java/com/samsamhajo/deepground/member/controller/MemberController.java
+++ b/src/main/java/com/samsamhajo/deepground/member/controller/MemberController.java
@@ -11,21 +11,19 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/members")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PutMapping("/profile")
-    public ResponseEntity<SuccessResponse> editMemberProfile(@RequestBody @Valid MemberProfileDto memberprofile,
-                                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+    @PutMapping("/{memberId}/profile")
+    public ResponseEntity<SuccessResponse> editMemberProfile(@RequestParam Long memberId,
+                                                             @RequestBody @Valid MemberProfileDto memberprofile) {
 
-        Long memberId = userDetails.getMember().getId();
         MemberProfileDto profile = memberService.editMemberProfile(memberId, memberprofile);
         return ResponseEntity
                 .ok(SuccessResponse.of(ProfileSuccessCode.PROFILE_SUCCESS_CODE,profile));

--- a/src/main/java/com/samsamhajo/deepground/member/exception/ProfileErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/member/exception/ProfileErrorCode.java
@@ -1,0 +1,25 @@
+package com.samsamhajo.deepground.member.exception;
+
+import com.samsamhajo.deepground.global.error.core.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum ProfileErrorCode implements ErrorCode {
+
+    INVALID_PROFILE_ID(HttpStatus.BAD_REQUEST, "회원의 프로필이 존재하지 않습니다.");
+
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[PROFILE ERROR]" + message;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/member/exception/ProfileException.java
+++ b/src/main/java/com/samsamhajo/deepground/member/exception/ProfileException.java
@@ -1,0 +1,10 @@
+package com.samsamhajo.deepground.member.exception;
+
+import com.samsamhajo.deepground.global.error.core.BaseException;
+
+public class ProfileException extends BaseException {
+
+    public ProfileException(ProfileErrorCode errorCode) {super(errorCode);}
+}
+
+

--- a/src/main/java/com/samsamhajo/deepground/member/service/MemberService.java
+++ b/src/main/java/com/samsamhajo/deepground/member/service/MemberService.java
@@ -5,6 +5,8 @@ import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.entity.MemberProfile;
 import com.samsamhajo.deepground.member.exception.MemberErrorCode;
 import com.samsamhajo.deepground.member.exception.MemberException;
+import com.samsamhajo.deepground.member.exception.ProfileErrorCode;
+import com.samsamhajo.deepground.member.exception.ProfileException;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
 import com.samsamhajo.deepground.member.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +27,8 @@ public class MemberService {
 
         member.updateNickname(memberProfileDto.getNickname());
 
-        MemberProfile profile = profileRepository.findByMemberId(memberId).get();
+        MemberProfile profile = profileRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ProfileException(ProfileErrorCode.INVALID_PROFILE_ID));
 
         profile.update(memberProfileDto);
 


### PR DESCRIPTION
## 📌 개요
- `@AuthenticationPrincipal`을 통해 회원 정보를 가져오는 기존 방식에서, `memberId`를 직접 전달받아 사용자 정보를 조회하도록 리팩터링했습니다.

## 🛠️ 작업 내용
- 친구 요청 시 `@RequestParam`으로 전달받은 `memberId`를 통해 요청 사용자 정보를 조회하도록 수정했습니다.
- 프로필 편집 시 `@PathVariable`로 전달된 `memberId`로 회원을 식별해 프로필을 조회하고 수정하도록 변경했습니다.
- `ProfileErrorCode` 클래스를 추가하여 프로필 관련 예외 처리 코드를 분리했습니다.

## 📌 차후 계획 (Optional)
- 회원가입 및 로그인 API 구현 이후, 프로필 편집 기능에 대한 Swagger 테스트 진행 예정  
  ( 현재 인증 기반 API 미구현으로 인해 400 에러 발생)

## 📌 테스트 케이스
- 기능 정상 동작 
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수 
- 기존 테스트 통과 

Close #220 