### PR TITLE
[Feature] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/auth/controller/AuthController.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/controller/AuthController.java
@@ -1,12 +1,15 @@
 package com.samsamhajo.deepground.auth.controller;
 
 import com.samsamhajo.deepground.auth.dto.*;
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.auth.service.AuthService;
 import com.samsamhajo.deepground.auth.success.AuthSuccessCode;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.member.entity.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -84,5 +87,14 @@ public class AuthController {
                 .body(SuccessResponse.of(AuthSuccessCode.TOKEN_REFRESHED, response));
     }
 
-    @PostMapping()
+    @PostMapping("/logout")
+    public ResponseEntity<SuccessResponse<Void>> logout(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails.getMember().getId();
+        authService.logout(memberId);
+        return ResponseEntity
+                .status(AuthSuccessCode.LOGOUT_SUCCESS.getStatus())
+                .body(SuccessResponse.of(AuthSuccessCode.LOGOUT_SUCCESS));
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/auth/controller/AuthController.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/controller/AuthController.java
@@ -83,4 +83,6 @@ public class AuthController {
                 .status(AuthSuccessCode.TOKEN_REFRESHED.getStatus())
                 .body(SuccessResponse.of(AuthSuccessCode.TOKEN_REFRESHED, response));
     }
+
+    @PostMapping()
 }

--- a/src/main/java/com/samsamhajo/deepground/auth/service/AuthService.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/service/AuthService.java
@@ -136,6 +136,12 @@ public class AuthService {
         return new TokenRefreshResponse(newAccessToken, currentRefreshToken);
     }
 
+    @Transactional
+    public void logout(Long memberId) {
+        //Redis에서 Refresh Token 삭제
+        refreshTokenRepository.deleteByMemberId(memberId);
+    }
+
     public void checkEmailDuplicate(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new AuthException(AuthErrorCode.DUPLICATE_EMAIL);

--- a/src/main/java/com/samsamhajo/deepground/auth/success/AuthSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/success/AuthSuccessCode.java
@@ -24,7 +24,9 @@ public enum AuthSuccessCode implements SuccessCode {
 
     PASSWORD_RESET_SUCCESS(HttpStatus.OK, "비밀번호가 성공적으로 재설정되었습니다."),
 
-    TOKEN_REFRESHED(HttpStatus.OK, "토큰이 갱신되었습니다.");
+    TOKEN_REFRESHED(HttpStatus.OK, "토큰이 갱신되었습니다."),
+
+    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/samsamhajo/deepground/auth/service/LogoutTest.java
+++ b/src/test/java/com/samsamhajo/deepground/auth/service/LogoutTest.java
@@ -1,0 +1,75 @@
+package com.samsamhajo.deepground.auth.service;
+
+import com.samsamhajo.deepground.auth.dto.LoginRequest;
+import com.samsamhajo.deepground.auth.dto.LoginResponse;
+import com.samsamhajo.deepground.auth.repository.RefreshTokenRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class LogoutTest {
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Member member;
+
+    @BeforeEach
+    void setup() {
+        member = Member.createLocalMember(
+                "test@example.com",
+                passwordEncoder.encode("password123"),
+                "test01"
+        );
+        memberRepository.save(member);
+    }
+
+    @Test
+    void 로그아웃_시_Refresh_Token_삭제() {
+        // given
+        refreshTokenRepository.save(member.getId(), "refresh_token", 3600L);
+
+        // Redis에 Refresh Token이 저장되어 있는지 확인
+        assertNotNull(refreshTokenRepository.findByMemberId(member.getId()));
+
+        // when
+        authService.logout(member.getId());
+
+        // then
+        assertNull(refreshTokenRepository.findByMemberId(member.getId()));
+    }
+
+    @Test
+    void 로그아웃_후_재로그인하면_새로운_Refresh_Token_발급() {
+        // given
+        refreshTokenRepository.save(member.getId(), "initial_token", 3600L);
+
+        // when
+        authService.logout(member.getId());
+        LoginRequest loginRequest = new LoginRequest(member.getEmail(), "password123");
+        LoginResponse loginResponse = authService.login(loginRequest);
+
+        // then
+        String newRefreshToken = refreshTokenRepository.findByMemberId(member.getId());
+        assertNotNull(newRefreshToken);
+        assertNotEquals("initial_token", newRefreshToken);
+        assertEquals(loginResponse.getRefreshToken(), newRefreshToken);
+    }
+}


### PR DESCRIPTION
## 📌 개요
로그아웃 기능을 구현했습니다.

## 🛠️ 작업 내용
1. 로그아웃 API 구현 (/api/v1/auth/logout)
   - 현재 인증된 사용자의 Refresh Token 삭제
   - Redis에서 토큰 정보 제거
   - @AuthenticationPrincipal을 통한 현재 사용자 식별

2. Redis 연동
   - Refresh Token 저장소에서 토큰 삭제
   - memberId를 key로 사용 (RT:{memberId})

3. 테스트 코드 작성
   - 로그아웃 기능 단위 테스트
   - Redis 연동 테스트

## 📌 테스트 결과
![image](https://github.com/user-attachments/assets/95b1b4b2-cd8b-4141-91b2-f9b1318160df)

## 📌 테스트 케이스
- [x] 정상적인 로그아웃 처리 확인
- [x] Redis에서 Refresh Token 삭제 확인

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.