### PR TITLE
[Feature] 스터디 운영 정보(참가자/승인 상태) 조회 API 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupAdminController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupAdminController.java
@@ -1,0 +1,39 @@
+package com.samsamhajo.deepground.studyGroup.controller;
+
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.service.StudyGroupAdminViewService;
+import com.samsamhajo.deepground.studyGroup.success.StudyGroupSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-group")
+public class StudyGroupAdminController {
+
+  private final StudyGroupAdminViewService adminViewService;
+  private final MemberRepository memberRepository;
+
+  // TODO: 스프링 시큐리티 구현 완료시, memberId 제외하고 RequestAttribute 도입 고려
+  @GetMapping("/{studyGroupId}/admin/{memberId}")
+  public ResponseEntity<SuccessResponse<?>> getAdminInfo(
+      @PathVariable Long studyGroupId,
+      @PathVariable Long memberId
+  ) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+
+    var response = adminViewService.getAdminView(member, studyGroupId);
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.READ_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.READ_SUCCESS, response));
+  }
+}
+

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupAdminViewResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupAdminViewResponse.java
@@ -1,0 +1,24 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StudyGroupAdminViewResponse {
+  private Long studyGroupId;
+  private String studyTitle;
+  private int totalMembers;
+  private int approvedCount;
+  private int waitingCount;
+  private List<MemberStatusDto> members;
+
+  @Getter
+  @Builder
+  public static class MemberStatusDto {
+    private Long memberId;
+    private String nickname;
+    private Boolean isAllowed;
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
@@ -6,6 +6,8 @@ import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +17,10 @@ public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMemb
   Optional<StudyGroupMember> findByMemberAndStudyGroup(Member member, StudyGroup studyGroup);
 
   List<StudyGroupMember> findAllByMemberIdAndIsAllowedTrueOrderByStudyGroupCreatedAtDesc(Long memberId);
+
+  @Query("SELECT m FROM StudyGroupMember m JOIN FETCH m.member WHERE m.studyGroup.id = :studyGroupId")
+  List<StudyGroupMember> findAllWithMemberByStudyGroupId(@Param("studyGroupId") Long studyGroupId);
+
+  int countByStudyGroup_IdAndIsAllowedTrue(Long studyGroupId);
+  int countByStudyGroup_IdAndIsAllowedFalse(Long studyGroupId);
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAdminViewService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAdminViewService.java
@@ -1,0 +1,54 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupAdminViewResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupAdminViewService {
+  private final StudyGroupRepository studyGroupRepository;
+  private final StudyGroupMemberRepository studyGroupMemberRepository;
+
+  public StudyGroupAdminViewResponse getAdminView(Member requester, Long studyGroupId) {
+    StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
+        .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
+
+    if (!studyGroup.getMember().getId().equals(requester.getId())) {
+      throw new AccessDeniedException("해당 스터디 그룹의 생성자가 아닙니다.");
+    }
+
+    List<StudyGroupMember> memberList =
+        studyGroupMemberRepository.findAllWithMemberByStudyGroupId(studyGroupId);
+
+    int approved = studyGroupMemberRepository.countByStudyGroup_IdAndIsAllowedTrue(studyGroupId);
+    int waiting = studyGroupMemberRepository.countByStudyGroup_IdAndIsAllowedFalse(studyGroupId);
+
+    List<StudyGroupAdminViewResponse.MemberStatusDto> members = memberList.stream()
+        .map(m -> StudyGroupAdminViewResponse.MemberStatusDto.builder()
+            .memberId(m.getMember().getId())
+            .nickname(m.getMember().getNickname())
+            .isAllowed(m.getIsAllowed())
+            .build())
+        .collect(Collectors.toList());
+
+    return StudyGroupAdminViewResponse.builder()
+        .studyGroupId(studyGroup.getId())
+        .studyTitle(studyGroup.getTitle())
+        .totalMembers(members.size())
+        .approvedCount(approved)
+        .waitingCount(waiting)
+        .members(members)
+        .build();
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAdminViewServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAdminViewServiceTest.java
@@ -1,0 +1,120 @@
+// StudyGroupAdminViewServiceTest
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupAdminViewResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+class StudyGroupAdminViewServiceTest extends IntegrationTestSupport {
+
+  @Autowired
+  private StudyGroupAdminViewService adminViewService;
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private StudyGroupMemberRepository studyGroupMemberRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @PersistenceContext
+  private EntityManager em;
+
+  private Member writer;
+  private Member approvedUser;
+  private Member waitingUser;
+  private Long studyGroupId;
+
+  @BeforeEach
+  void setUp() {
+    writer = Member.createLocalMember("host@test.com", "1234", "운영자");
+    approvedUser = Member.createLocalMember("user1@test.com", "1234", "참여자1");
+    waitingUser = Member.createLocalMember("user2@test.com", "1234", "대기자");
+
+    memberRepository.save(writer);
+    memberRepository.save(approvedUser);
+    memberRepository.save(waitingUser);
+
+    StudyGroup group = StudyGroup.of(
+        null, "운영 테스트 스터디", "운영자 확인용",
+        LocalDate.now().plusDays(1),
+        LocalDate.now().plusDays(10),
+        LocalDate.now(),
+        LocalDate.now().plusDays(5),
+        10,
+        writer,
+        true,
+        "역삼"
+    );
+    studyGroupRepository.save(group);
+
+    studyGroupMemberRepository.save(StudyGroupMember.of(approvedUser, group, true));
+    studyGroupMemberRepository.save(StudyGroupMember.of(waitingUser, group, false));
+
+    em.flush();
+    em.clear();
+
+    studyGroupId = group.getId();
+  }
+
+  @Test
+  @DisplayName("스터디 운영자가 관리 정보 요청 시 참가자 상태 및 통계를 조회할 수 있다")
+  void getAdminView_success() {
+    // when
+    StudyGroupAdminViewResponse response = adminViewService.getAdminView(writer, studyGroupId);
+
+    // then
+    assertThat(response.getStudyTitle()).isEqualTo("운영 테스트 스터디");
+    assertThat(response.getTotalMembers()).isEqualTo(2);
+    assertThat(response.getApprovedCount()).isEqualTo(1);
+    assertThat(response.getWaitingCount()).isEqualTo(1);
+
+    assertThat(response.getMembers())
+        .extracting(StudyGroupAdminViewResponse.MemberStatusDto::getNickname)
+        .containsExactlyInAnyOrder("참여자1", "대기자");
+
+    assertThat(response.getMembers())
+        .anyMatch(m -> m.getNickname().equals("참여자1") && Boolean.TRUE.equals(m.getIsAllowed()));
+
+    assertThat(response.getMembers())
+        .anyMatch(m -> m.getNickname().equals("대기자") && Boolean.FALSE.equals(m.getIsAllowed()));
+  }
+
+  @Test
+  @DisplayName("스터디 운영자가 아닌 사용자가 요청 시 예외가 발생한다")
+  void getAdminView_accessDenied() {
+    // when & then
+    assertThatThrownBy(() -> adminViewService.getAdminView(waitingUser, studyGroupId))
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 스터디 ID로 요청 시 예외 발생")
+  void getAdminView_notFound() {
+    // when & then
+    assertThatThrownBy(() -> adminViewService.getAdminView(writer, -999L))
+        .hasMessageContaining("스터디 그룹을 찾을 수 없습니다");
+  }
+}


### PR DESCRIPTION
## **📌 개요**

- 스터디 생성자가 자신이 만든 스터디에 대해 운영 정보를 조회할 수 있도록 하는 API를 추가했습니다.
    이 기능은 승인된 참가자 수, 대기자 수, 전체 참가자 목록 등을 포함하며, 생성자 본인만 접근 가능합니다.

## **🛠️ 작업 내용**

- StudyGroupAdminViewService 서비스 로직 구현
- StudyGroupAdminController 컨트롤러 추가 (임시로 memberId PathVariable 방식 사용)
- StudyGroupAdminViewResponse DTO 구성
- StudyGroupMemberRepository에 쿼리 메서드 추가 (countBy..., findAllWithMemberByStudyGroupId)
- 통합 테스트 코드 작성 (StudyGroupAdminViewServiceTest)

  

### **✅ 운영 정보 응답 DTO 구성**

- 운영자는 다음 정보를 확인할 수 있습니다.
    - 스터디 제목
    - 전체 참가자 수
    - 승인된 참가자 수
    - 대기 중인 참가자 수
    - 각 멤버의 닉네임과 승인 여부 리스트

### **✅ 예외 처리**

- 본인이 아닌 경우 AccessDeniedException 발생
- 존재하지 않는 스터디 ID 요청 시 StudyGroupNotFoundException 발생

## **📌 차후 계획 (Optional)**

- Spring Security 적용 후 @RequestAttribute("member") → @AuthenticationPrincipal 방식으로 전환 예정
- 거절된 참가자 처리 및 필터링 옵션 추가

## **📌 테스트 케이스**

- 운영자 기준 정상 응답 반환
- 참가자 기준 접근 시 403 Forbidden 예외 확인
- 잘못된 ID 요청 시 StudyGroupNotFoundException 발생 확인
- StudyGroupMember에 승인/대기자 정상 카운팅 확인

```
assertThat(response.getApprovedCount()).isEqualTo(1);
assertThat(response.getWaitingCount()).isEqualTo(1);
```

## **📌 기타 참고 사항**

- 현재는 시큐리티 미적용 상태이므로 GET /study-group/{studyGroupId}/admin/{memberId}로 조회
- DTO는 확장 가능하도록 Builder 기반으로 구성
- 테스트 시 flush + clear를 통해 엔티티 ID 보장 및 영속성 컨텍스트 분리 처리

---

#### **🙏🏻아래와 같이 PR을 리뷰해주세요.**

- 기능에 대한 테스트가 충분히 이루어졌는지 확인해주세요.
- API 응답 구조가 직관적인지 검토해주세요.
- 멤버 필드 노출 범위 (nickname, isAllowed)가 적절한지 확인해주세요.
- 예외 처리 로직이 누락된 케이스는 없는지 검토해주세요.

Closes #113