### PR TITLE
[Feature] 댓글에 대한 답글(대댓글) 작성 기능 추가

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupReplyController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupReplyController.java
@@ -1,0 +1,40 @@
+package com.samsamhajo.deepground.studyGroup.controller;
+
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupReplyRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupReplyResponse;
+import com.samsamhajo.deepground.studyGroup.service.StudyGroupReplyService;
+import com.samsamhajo.deepground.studyGroup.success.StudyGroupSuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-group/replies")
+public class StudyGroupReplyController {
+
+  private final StudyGroupReplyService replyService;
+  private final MemberRepository memberRepository;
+
+  @PostMapping("/{memberId}")
+  public ResponseEntity<SuccessResponse<StudyGroupReplyResponse>> writeReply(
+      @PathVariable Long memberId,
+      @RequestBody @Valid StudyGroupReplyRequest request
+  ) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+    StudyGroupReplyResponse response = replyService.writeReply(member, request);
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.CREATE_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.CREATE_SUCCESS, response));
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupReplyRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupReplyRequest.java
@@ -1,0 +1,17 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupReplyRequest {
+  @NotNull(message = "부모 댓글 ID는 필수입니다.")
+  private Long commentId;
+
+  @NotBlank(message = "답글 내용은 비어 있을 수 없습니다.")
+  private String content;
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupReplyResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupReplyResponse.java
@@ -1,0 +1,17 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StudyGroupReplyResponse {
+  private Long replyId;
+  private Long parentCommentId;
+  private String writerNickname;
+  private String content;
+  private LocalDateTime createdAt;
+}
+

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupReplyRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupReplyRepository.java
@@ -1,0 +1,12 @@
+package com.samsamhajo.deepground.studyGroup.repository;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyGroupReplyRepository extends JpaRepository<StudyGroupReply, Long> {
+  List<StudyGroupReply> findAllByComment_IdOrderByCreatedAtAsc(Long commentId);
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupReplyService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupReplyService.java
@@ -1,0 +1,36 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupReplyRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupReplyResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupReply;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupCommentRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupReplyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupReplyService {
+  private final StudyGroupReplyRepository replyRepository;
+  private final StudyGroupCommentRepository commentRepository;
+
+  @Transactional
+  public StudyGroupReplyResponse writeReply(Member writer, StudyGroupReplyRequest request) {
+    StudyGroupComment parentComment = commentRepository.findById(request.getCommentId())
+        .orElseThrow(() -> new IllegalArgumentException(request.getCommentId() + "가 존재하지 않습니다."));
+
+    StudyGroupReply reply = StudyGroupReply.of(parentComment, writer, request.getContent());
+    StudyGroupReply saved = replyRepository.save(reply);
+
+    return StudyGroupReplyResponse.builder()
+        .replyId(saved.getId())
+        .parentCommentId(parentComment.getId())
+        .writerNickname(writer.getNickname())
+        .content(saved.getContent())
+        .createdAt(saved.getCreatedAt())
+        .build();
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupReplyServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupReplyServiceTest.java
@@ -1,0 +1,99 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupReplyRequest;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupReplyResponse;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupCommentRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupReplyRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+class StudyGroupReplyServiceTest extends IntegrationTestSupport {
+
+  @Autowired private StudyGroupReplyService replyService;
+  @Autowired private StudyGroupReplyRepository replyRepository;
+  @Autowired private StudyGroupCommentRepository commentRepository;
+  @Autowired private StudyGroupRepository groupRepository;
+  @Autowired private MemberRepository memberRepository;
+
+  @PersistenceContext private EntityManager em;
+
+  private Long commentId;
+  private Member writer;
+
+  @BeforeEach
+  void setUp() {
+    writer = Member.createLocalMember("replyer@test.com", "pw", "답글작성자");
+    Member commenter = Member.createLocalMember("commenter@test.com", "pw", "댓글작성자");
+    memberRepository.save(writer);
+    memberRepository.save(commenter);
+
+    StudyGroup group = StudyGroup.of(
+        null, "스터디 제목", "설명",
+        LocalDate.now().plusDays(1), LocalDate.now().plusDays(3),
+        LocalDate.now(), LocalDate.now().plusDays(2),
+        5, commenter, true, "강남"
+    );
+    groupRepository.save(group);
+
+    StudyGroupComment comment = StudyGroupComment.of(group, commenter, "원댓글입니다");
+    commentRepository.save(comment);
+
+    em.flush();
+    em.clear();
+
+    commentId = comment.getId();
+  }
+
+  @Test
+  @DisplayName("부모 댓글 ID로 답글을 작성할 수 있다")
+  void writeReply_success() {
+    // given
+    StudyGroupReplyRequest request = StudyGroupReplyRequest.builder()
+        .commentId(commentId)
+        .content("답글입니다")
+        .build();
+
+    // when
+    StudyGroupReplyResponse response = replyService.writeReply(writer, request);
+
+    // then
+    assertThat(response.getParentCommentId()).isEqualTo(commentId);
+    assertThat(response.getWriterNickname()).isEqualTo("답글작성자");
+    assertThat(response.getContent()).isEqualTo("답글입니다");
+    assertThat(response.getReplyId()).isNotNull();
+    assertThat(response.getCreatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 댓글 ID로 답글을 작성하면 예외가 발생한다")
+  void writeReply_commentNotFound() {
+    // given
+    StudyGroupReplyRequest request = StudyGroupReplyRequest.builder()
+        .commentId(-1L)
+        .content("답글")
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> replyService.writeReply(writer, request))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
## **📌 개요**

- 기존 댓글에 대한 답글을 작성할 수 있는 기능을 구현했습니다.
    이를 통해 댓글 스레드 구조가 가능해졌으며, 추후 스터디 상세 페이지에서 트리 형태의 커뮤니케이션 UI 구현이 가능해집니다.

---

## **🛠️ 작업 내용**

- StudyGroupReplyRequest / StudyGroupReplyResponse DTO 추가
- StudyGroupReplyService 서비스 로직 구현
- StudyGroupReplyRepository 작성
- StudyGroupReplyController 추가 (memberId PathVariable 방식으로 작성자 주입)
- 통합 테스트 StudyGroupReplyServiceTest 작성

  

### **✅ 답글 저장 API**

|**메서드**|**경로**|
|---|---|
|POST|/study-group/replies/{memberId}|

- 요청 JSON: { commentId: Long, content: String }
- 응답 JSON: replyId, parentCommentId, writerNickname, content, createdAt

---

## **📌 차후 계획 (Optional)**

- 인증 기반으로 @AuthenticationPrincipal 적용 예정 (현재는 memberId PathVariable 사용 중)

---

## **📌 테스트 케이스**

- 정상적인 답글 작성 흐름 검증
- 존재하지 않는 댓글에 답글 작성 시 예외 검증
- DTO 필드 매핑 및 응답 값 검증
- 영속성 컨텍스트 분리 확인 (flush + clear)

```
assertThat(response.getWriterNickname()).isEqualTo("답글작성자");
assertThat(response.getReplyId()).isNotNull();
```

---

## **📌 기타 참고 사항**

- 인증 미적용 상황에서는 임시로 memberId를 PathVariable로 전달받아 처리하고 있습니다.
- StudyGroupReplyServiceTest를 통해 비정상 흐름까지 명확하게 커버했습니다.
- 서비스 구조상 댓글 엔티티와의 연관관계를 유지하며, 답글 정렬은 createdAt 기준입니다.

---

#### **🙏🏻아래와 같이 PR을 리뷰해주세요.**

- 답글 등록 로직이 일관된 도메인 흐름을 따르는지 확인해주세요.
- 댓글/답글 DTO 구조가 이후 트리 응답에도 확장 가능한지 확인해주세요.
- 예외 처리와 예외 메시지 전달이 명확한지 봐주세요.
- 테스트 커버리지가 충분한지 확인해주세요.

Closes #110 