### PR TITLE
[Feature] 피드 답글 삭제하기

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
@@ -38,4 +38,14 @@ public class FeedReplyController {
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_UPDATED));
     }
+
+    @DeleteMapping("/{feedReplyId}")
+    public ResponseEntity<SuccessResponse<?>> deleteFeedReply(
+            @PathVariable("feedReplyId") Long feedReplyId) {
+
+        feedReplyService.deleteFeedReply(feedReplyId);
+
+        return ResponseEntity
+                .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_DELETED));
+    }
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/entity/FeedReply.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/entity/FeedReply.java
@@ -8,6 +8,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "feed_replies")
@@ -25,6 +27,7 @@ public class FeedReply extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_comment_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private FeedComment feedComment;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/entity/FeedReplyLike.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/entity/FeedReplyLike.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "feed_reply_likes")
@@ -21,6 +23,7 @@ public class FeedReplyLike extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_reply_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private FeedReply feedReply;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/entity/FeedReplyMedia.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/entity/FeedReplyMedia.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "feed_reply_media")
@@ -26,6 +28,7 @@ public class FeedReplyMedia extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_reply_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private FeedReply feedReply;
 
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/exception/FeedReplySuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/exception/FeedReplySuccessCode.java
@@ -11,7 +11,10 @@ public enum FeedReplySuccessCode implements SuccessCode {
     FEED_REPLY_CREATED(HttpStatus.CREATED, "답글이 생성되었습니다."),
     FEED_REPLY_UPDATED(HttpStatus.OK, "답글이 수정되었습니다."),
     FEED_REPLY_LIKED(HttpStatus.OK, "답글이 좋아요 되었습니다."),
-    FEED_REPLY_DISLIKED(HttpStatus.OK, "답글 좋아요가 취소되었습니다.");
+    FEED_REPLY_DISLIKED(HttpStatus.OK, "답글 좋아요가 취소되었습니다."),
+    FEED_REPLY_DELETED(HttpStatus.OK, "답글이 삭제되었습니다.")
+
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyMediaService.java
@@ -34,16 +34,25 @@ public class FeedReplyMediaService {
     }
 
     @Transactional
-    public void updateFeedReplyMedia(FeedReply feedReply, List<MultipartFile> images) {
-        if (CollectionUtils.isEmpty(images)) return;
+    public void deleteAllByFeedReplyId(Long feedReplyId) {
+        // 파일 시스템에서 물리적 미디어 파일 삭제
+        List<FeedReplyMedia> mediaList = feedReplyMediaRepository.findAllByFeedReplyId(feedReplyId);
+        for (FeedReplyMedia media : mediaList) {
+            MediaUtils.deleteMedia(media.getMediaUrl());
+        }
 
-        deleteFeedReplyMedia(feedReply.getId());
-
-        createFeedReplyMedia(feedReply, images);
+        // DB에서 삭제 (JPA Query Method 사용)
+        feedReplyMediaRepository.deleteAllByFeedReplyId(feedReplyId);
     }
 
     @Transactional
-    public void deleteFeedReplyMedia(Long feedReplyId) {
-        feedReplyMediaRepository.deleteAllByFeedReplyId(feedReplyId);
+    public void updateFeedReplyMedia(FeedReply feedReply, List<MultipartFile> images) {
+        if (CollectionUtils.isEmpty(images)) return;
+
+        // 피드에 연결된 모든 미디어 삭제
+        deleteAllByFeedReplyId(feedReply.getId());
+
+        // 새 미디어 추가
+        createFeedReplyMedia(feedReply, images);
     }
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
@@ -65,6 +65,18 @@ public class FeedReplyService {
         return feedReply;
     }
 
+    @Transactional
+    public void deleteFeedReply(Long feedReplyId) {
+        FeedReply feedReply = feedReplyRepository.getById(feedReplyId);
+
+        // 피드 답글 미디어 삭제
+        feedReplyMediaService.deleteFeedReplyMedia(feedReplyId);
+
+        // 논리적 삭제
+        feedReply.softDelete();
+    }
+
+
     private void saveFeedReplyMedia(FeedReplyCreateRequest request, FeedReply feedReply) {
         feedReplyMediaService.createFeedReplyMedia(feedReply, request.getImages());
     }

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
@@ -48,6 +48,7 @@ public class FeedReplyService {
 
         return feedComment;
     }
+
     @Transactional
     public FeedReply updateFeedReply(Long feedReplyId, FeedReplyUpdateRequest request) {
         if (!StringUtils.hasText(request.getContent())) {
@@ -70,10 +71,10 @@ public class FeedReplyService {
         FeedReply feedReply = feedReplyRepository.getById(feedReplyId);
 
         // 피드 답글 미디어 삭제
-        feedReplyMediaService.deleteFeedReplyMedia(feedReplyId);
+        feedReplyMediaService.deleteAllByFeedReplyId(feedReplyId);
 
-        // 논리적 삭제
-        feedReply.softDelete();
+        // 피드 삭제
+        feedReplyRepository.delete(feedReply);
     }
 
 

--- a/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyServiceTest.java
@@ -194,8 +194,8 @@ class FeedReplyServiceTest {
             feedReplyService.deleteFeedReply(feedReplyId);
 
             // then
-            verify(feedReplyMediaService, times(1)).deleteFeedReplyMedia(feedReplyId);
-            verify(feedReply, times(1)).softDelete();
+            verify(feedReplyMediaService, times(1)).deleteAllByFeedReplyId(feedReplyId);
+            verify(feedReplyRepository, times(1)).delete(feedReply);
         }
 
         @Test

--- a/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyServiceTest.java
@@ -178,4 +178,37 @@ class FeedReplyServiceTest {
                     .hasMessage(FeedReplyErrorCode.FEED_REPLY_NOT_FOUND.getMessage());
         }
     }
+
+    @Nested
+    @DisplayName("답글 삭제 케이스")
+    class DeleteCases {
+        @Test
+        @DisplayName("정상적으로 답글 삭제")
+        void deleteFeedReply_success() {
+            // given
+            Long feedReplyId = 1L;
+            FeedReply feedReply = mock(FeedReply.class);
+            when(feedReplyRepository.getById(feedReplyId)).thenReturn(feedReply);
+
+            // when
+            feedReplyService.deleteFeedReply(feedReplyId);
+
+            // then
+            verify(feedReplyMediaService, times(1)).deleteFeedReplyMedia(feedReplyId);
+            verify(feedReply, times(1)).softDelete();
+        }
+
+        @Test
+        @DisplayName("답글이 존재하지 않으면 예외 발생")
+        void deleteFeedReply_fail_replyNotFound() {
+            // given
+            Long feedReplyId = 1L;
+            when(feedReplyRepository.getById(feedReplyId)).thenThrow(new FeedReplyException(FeedReplyErrorCode.FEED_REPLY_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> feedReplyService.deleteFeedReply(feedReplyId))
+                    .isInstanceOf(FeedReplyException.class)
+                    .hasMessage(FeedReplyErrorCode.FEED_REPLY_NOT_FOUND.getMessage());
+        }
+    }
 } 


### PR DESCRIPTION
## 📌 개요

피드 답글 삭제 로직 구현하였습니다.

## 🛠️ 작업 내용
- [x] `FeedReply` 삭제 로직 및 API 구현
- [x] OnDelete Annoation 사용하여 연관관계 맺은 엔티티를 연쇄적으로 삭제: `FeedReplyMedia`, `FeedReplyLike`
- [x] `FeedReplyMediaService` 업데이트 로직 물리적 삭제 오류 수정
- [x] 관련 단위 테스트 코드 작성
- [x] #234 

### 📌  작업 결과

- `media` directory 내 물리적 삭제 여부 확인 완료
- 피드 생성 -> 피드 삭제 순서로 진행하여 각 단계별 데이터 베이스 반영여부 확인 완료
![image](https://github.com/user-attachments/assets/554f42d9-9b76-4fb1-8ae0-fb47c5a64b30)


## 📌 차후 계획 (Optional)
`Feed` `FeedComment` 도메인의 삭제 로직 및 업데이트 로직을 최신화 할 수 있도록 하겠습니다.


## 📌 테스트 케이스
- [x] 권한 관련 테스트 케이스 삭제
- [x] 코드 스타일 및 컨벤션 준수 확인 완료
- [x] 기존 테스트 통과 여부 확인 완료
- [x] 성공 및 실패 테스트 케이스 통과 확인 완료

### 📌 기타 참고 사항
OnDelete를 사용하여 연쇄적으로 삭제할 수 있도록 구현하였습니다. DB 성능상, 안정성 상의 단점이 우려된다면 말씀 부탁드립니다.


#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
closing #234 