### PR TITLE
[Feature]  단일 일정 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/controller/MemberStudyScheduleController.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/controller/MemberStudyScheduleController.java
@@ -2,6 +2,7 @@ package com.samsamhajo.deepground.calendar.controller;
 
 
 import com.samsamhajo.deepground.calendar.dto.MemberScheduleCalendarResponseDto;
+import com.samsamhajo.deepground.calendar.dto.MemberScheduleDetailResponseDto;
 import com.samsamhajo.deepground.calendar.dto.MemberStudyScheduleRequestDto;
 import com.samsamhajo.deepground.calendar.dto.MemberStudyScheduleResponseDto;
 import com.samsamhajo.deepground.calendar.exception.ScheduleSuccessCode;
@@ -21,8 +22,8 @@ public class MemberStudyScheduleController {
 
     private final MemberStudyScheduleService memberStudyScheduleService;
 
-    @GetMapping("/{memberId}")
-    public ResponseEntity<SuccessResponse<List<MemberScheduleCalendarResponseDto>>> getMemberStudySchedulesByMemberId(
+    @GetMapping("/member/{memberId}")
+    public ResponseEntity<SuccessResponse<List<MemberScheduleCalendarResponseDto>>> findMemberStudySchedulesByMemberId(
             @PathVariable Long memberId
     ) {
         List<MemberScheduleCalendarResponseDto> memberStudySchedules = memberStudyScheduleService.findAllByMemberId(memberId);
@@ -31,12 +32,22 @@ public class MemberStudyScheduleController {
                 .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_FOUND, memberStudySchedules));
     }
 
+    @GetMapping("/{memberStudyScheduleId}")
+    public ResponseEntity<SuccessResponse<MemberScheduleDetailResponseDto>> getScheduleByMemberScheduleId(
+            @PathVariable Long memberStudyScheduleId
+    ) {
+        MemberScheduleDetailResponseDto responseDto = memberStudyScheduleService.getScheduleByMemberScheduleId(memberStudyScheduleId);
+
+        return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_FOUND.getStatus())
+                .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_FOUND, responseDto));
+    }
+
     @PatchMapping("/{memberStudyScheduleId}")
-    public ResponseEntity<SuccessResponse<MemberStudyScheduleResponseDto>> update(
+    public ResponseEntity<SuccessResponse<MemberStudyScheduleResponseDto>> updateByMemberScheduleId(
             @PathVariable Long memberStudyScheduleId,
             @Valid @RequestBody MemberStudyScheduleRequestDto requestDto
     ) {
-        MemberStudyScheduleResponseDto responseDto = memberStudyScheduleService.update(memberStudyScheduleId, requestDto);
+        MemberStudyScheduleResponseDto responseDto = memberStudyScheduleService.updateMemberStudySchedule(memberStudyScheduleId, requestDto);
         return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_UPDATED.getStatus())
                 .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_UPDATED, responseDto));
     }

--- a/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberScheduleDetailResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberScheduleDetailResponseDto.java
@@ -8,23 +8,33 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-public class MemberScheduleCalendarResponseDto {
+public class MemberScheduleDetailResponseDto {
 
     private Long memberStudyScheduleId;
     private Long studyScheduleId;
     private String title;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
+    private String description;
+    private String location;
+    private Boolean isAvailable;
+    private Boolean isImportant;
+    private String memo;
 
-
-    public static MemberScheduleCalendarResponseDto from(MemberStudySchedule schedule) {
+    public static MemberScheduleDetailResponseDto from(MemberStudySchedule schedule) {
         var ss = schedule.getStudySchedule();
-        return MemberScheduleCalendarResponseDto.builder()
+        return MemberScheduleDetailResponseDto.builder()
                 .memberStudyScheduleId(schedule.getId())
                 .studyScheduleId(ss.getId())
                 .title(ss.getTitle())
                 .startTime(ss.getStartTime())
                 .endTime(ss.getEndTime())
+                .description(ss.getDescription())
+                .location(ss.getLocation())
+                .isAvailable(schedule.getIsAvailable())
+                .isImportant(schedule.getIsImportant())
+                .memo(schedule.getMemo())
                 .build();
     }
 }
+

--- a/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberStudyScheduleResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberStudyScheduleResponseDto.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.calendar.dto;
 
+import com.samsamhajo.deepground.calendar.entity.MemberStudySchedule;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +12,13 @@ public class MemberStudyScheduleResponseDto {
     private Boolean isAvailable;
     private Boolean isImportant;
     private String memo;
+
+    public static MemberStudyScheduleResponseDto from(MemberStudySchedule schedule) {
+        return MemberStudyScheduleResponseDto.builder()
+                .id(schedule.getId())
+                .isAvailable(schedule.getIsAvailable())
+                .isImportant(schedule.getIsImportant())
+                .memo(schedule.getMemo())
+                .build();
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
@@ -2,6 +2,7 @@ package com.samsamhajo.deepground.calendar.service;
 
 
 import com.samsamhajo.deepground.calendar.dto.MemberScheduleCalendarResponseDto;
+import com.samsamhajo.deepground.calendar.dto.MemberScheduleDetailResponseDto;
 import com.samsamhajo.deepground.calendar.dto.MemberStudyScheduleRequestDto;
 import com.samsamhajo.deepground.calendar.dto.MemberStudyScheduleResponseDto;
 
@@ -28,40 +29,45 @@ public class MemberStudyScheduleService {
         validateMember(memberId);
 
         List<MemberStudySchedule> schedules = memberStudyScheduleRepository.findAllByMemberId(memberId);
+
         return schedules.stream()
                 .map(MemberScheduleCalendarResponseDto::from)
                 .toList();
     }
 
     @Transactional
-    public MemberStudyScheduleResponseDto update (Long scheduleId, MemberStudyScheduleRequestDto requestDto){
+    public MemberScheduleDetailResponseDto getScheduleByMemberScheduleId(Long memberScheduleId) {
 
-        MemberStudySchedule schedule = memberStudyScheduleRepository.findById(scheduleId)
+        MemberStudySchedule memberStudySchedule = memberStudyScheduleRepository.findById(memberScheduleId)
+                .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+
+        return MemberScheduleDetailResponseDto.from(memberStudySchedule);
+    }
+
+    @Transactional
+    public MemberStudyScheduleResponseDto updateMemberStudySchedule (Long memberScheduleId, MemberStudyScheduleRequestDto requestDto){
+
+        MemberStudySchedule memberStudySchedule = memberStudyScheduleRepository.findById(memberScheduleId)
                 .orElseThrow(() -> new ScheduleException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
 
         if (requestDto.getIsAvailable() != null) {
-            schedule.updateAvailable(requestDto.getIsAvailable());
+            memberStudySchedule.updateAvailable(requestDto.getIsAvailable());
 
-            if (Boolean.FALSE.equals(schedule.getIsAvailable())) {
-                schedule.updateImportant(false);
-                schedule.updateMemo(null);
+            if (Boolean.FALSE.equals(memberStudySchedule.getIsAvailable())) {
+                memberStudySchedule.updateImportant(false);
+                memberStudySchedule.updateMemo(null);
             } else {
                 // 참석 중일 때만 개별 필드 업데이트
                 if (requestDto.getIsImportant() != null) {
-                    schedule.updateImportant(requestDto.getIsImportant());
+                    memberStudySchedule.updateImportant(requestDto.getIsImportant());
                 }
                 if (requestDto.getMemo() != null) {
-                    schedule.updateMemo(requestDto.getMemo());
+                    memberStudySchedule.updateMemo(requestDto.getMemo());
                 }
             }
         }
 
-        return MemberStudyScheduleResponseDto.builder()
-                .id(schedule.getId())
-                .isAvailable(schedule.getIsAvailable())
-                .isImportant(schedule.getIsImportant())
-                .memo(schedule.getMemo())
-                .build();
+        return MemberStudyScheduleResponseDto.from(memberStudySchedule);
     }
 
     private void validateMember(Long memberId) {

--- a/src/test/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleServiceTest.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.calendar.service;
 
 import com.samsamhajo.deepground.calendar.dto.MemberScheduleCalendarResponseDto;
+import com.samsamhajo.deepground.calendar.dto.MemberScheduleDetailResponseDto;
 import com.samsamhajo.deepground.calendar.dto.MemberStudyScheduleRequestDto;
 import com.samsamhajo.deepground.calendar.dto.MemberStudyScheduleResponseDto;
 import com.samsamhajo.deepground.calendar.entity.MemberStudySchedule;
@@ -52,8 +53,6 @@ public class MemberStudyScheduleServiceTest {
         when(studySchedule.getTitle()).thenReturn("스터디 일정 제목");
         when(studySchedule.getStartTime()).thenReturn(LocalDateTime.of(2025, 5, 30, 14, 0));
         when(studySchedule.getEndTime()).thenReturn(LocalDateTime.of(2025, 5, 30, 16, 0));
-        when(studySchedule.getDescription()).thenReturn("스터디 일정 설명");
-        when(studySchedule.getLocation()).thenReturn("온라인");
 
         MemberStudySchedule memberStudySchedule = MemberStudySchedule.of(studySchedule, true, true, "memo");
 
@@ -71,11 +70,6 @@ public class MemberStudyScheduleServiceTest {
         assertThat(dto.getTitle()).isEqualTo("스터디 일정 제목");
         assertThat(dto.getStartTime()).isEqualTo(LocalDateTime.of(2025, 5, 30, 14, 0));
         assertThat(dto.getEndTime()).isEqualTo(LocalDateTime.of(2025, 5, 30, 16, 0));
-        assertThat(dto.getDescription()).isEqualTo("스터디 일정 설명");
-        assertThat(dto.getLocation()).isEqualTo("온라인");
-        assertThat(dto.getIsAvailable()).isTrue();
-        assertThat(dto.getIsImportant()).isTrue();
-        assertThat(dto.getMemo()).isEqualTo("memo");
     }
 
     @Test
@@ -92,6 +86,55 @@ public class MemberStudyScheduleServiceTest {
 
         verify(memberRepository).findById(memberId);
         verify(memberStudyScheduleRepository, never()).findAllByMemberId(anyLong());
+    }
+
+    @Test
+    @DisplayName("멤버 스터디 일정 상세 정보 조회 성공")
+    void getMemberStudySchedule_success() {
+        // given
+        Long memberStudyScheduleId = 1L;
+
+        // studySchedule mock 설정
+        StudySchedule studySchedule = mock(StudySchedule.class);
+        when(studySchedule.getTitle()).thenReturn("자바 스터디");
+        when(studySchedule.getStartTime()).thenReturn(LocalDateTime.of(2025, 6, 4, 14, 0));
+        when(studySchedule.getEndTime()).thenReturn(LocalDateTime.of(2025, 6, 4, 16, 0));
+        when(studySchedule.getDescription()).thenReturn("자바 공부");
+        when(studySchedule.getLocation()).thenReturn("온라인");
+
+        // memberStudySchedule mock 설정\
+        MemberStudySchedule memberStudySchedule = mock(MemberStudySchedule.class);
+        when(memberStudySchedule.getId()).thenReturn(memberStudyScheduleId);
+        when(memberStudySchedule.getIsAvailable()).thenReturn(true);
+        when(memberStudySchedule.getIsImportant()).thenReturn(true);
+        when(memberStudySchedule.getMemo()).thenReturn("메모");
+        when(memberStudySchedule.getStudySchedule()).thenReturn(studySchedule);
+
+        when(memberStudyScheduleRepository.findById(memberStudyScheduleId))
+                .thenReturn(Optional.of(memberStudySchedule));
+
+        // when
+        MemberScheduleDetailResponseDto responseDto = memberStudyScheduleService.getScheduleByMemberScheduleId(memberStudyScheduleId);
+
+        // then
+        assertThat(responseDto.getIsAvailable()).isTrue();
+        assertThat(responseDto.getIsImportant()).isTrue();
+        assertThat(responseDto.getMemo()).isEqualTo("메모");
+        assertThat(responseDto.getTitle()).isEqualTo("자바 스터디");
+        assertThat(responseDto.getStartTime()).isEqualTo(LocalDateTime.of(2025, 6, 4, 14, 0));
+    }
+
+    @Test
+    @DisplayName("멤버 스터디 일정 상세 정보 조회 실패 - 존재하지 않는 일정")
+    void getMemberStudySchedule_fail_scheduleNotFound() {
+        // given
+        Long memberStudyScheduleId = 1L;
+        when(memberStudyScheduleRepository.findById(memberStudyScheduleId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberStudyScheduleService.getScheduleByMemberScheduleId(memberStudyScheduleId))
+                .isInstanceOf(ScheduleException.class)
+                .hasMessageContaining(ScheduleErrorCode.SCHEDULE_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -113,7 +156,7 @@ public class MemberStudyScheduleServiceTest {
                 .thenReturn(Optional.of(memberStudySchedule));
 
         // when
-        MemberStudyScheduleResponseDto response = memberStudyScheduleService.update(memberStudyScheduleId, requestDto);
+        MemberStudyScheduleResponseDto response = memberStudyScheduleService.updateMemberStudySchedule(memberStudyScheduleId, requestDto);
 
         // then
         assertThat(response.getId()).isEqualTo(memberStudySchedule.getId());
@@ -137,7 +180,7 @@ public class MemberStudyScheduleServiceTest {
         when(memberStudyScheduleRepository.findById(invalidMemberStudyScheduleId))
                 .thenReturn(Optional.empty());
         // when & then
-        assertThatThrownBy(() -> memberStudyScheduleService.update(invalidMemberStudyScheduleId, requestDto))
+        assertThatThrownBy(() -> memberStudyScheduleService.updateMemberStudySchedule(invalidMemberStudyScheduleId, requestDto))
                 .isInstanceOf(ScheduleException.class)
                 .hasMessageContaining(ScheduleErrorCode.SCHEDULE_NOT_FOUND.getMessage());
         }


### PR DESCRIPTION
## 📌 개요

* 단일 일정 상세 조회 API 구현 & 전체 일정 조회 응답 필드 수정

## 🛠️ 작업 내용
-  단일 일정 상세 조회 API 구현
- 전체 일정 조회 응답 DTO (MemberScheduleCalendarResponseDto)에서 description, location 등 불필요한 필드 제거
- MemberStudyScheduleResponseDto에 정적 팩토리 메서드 from() 추가로 서비스 응답 로직 리팩토링


## 📌 테스트 케이스
- 단일 일정 ID로 상세 조회 시 title, startTime 등 정확히 응답되는지 확인
- 존재하지 않는 일정 ID 요청 시 ScheduleException 발생하는지 확인
- 기존 테스트 모두 통과


### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---
closes #88 