### PR TITLE
[Feature] 소셜 로그인 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/auth/controller/OAuthController.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/controller/OAuthController.java
@@ -1,0 +1,40 @@
+package com.samsamhajo.deepground.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.servlet.view.RedirectView;
+
+@Controller
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private static final String OAUTH2_AUTHORIZATION_BASE_URI = "/oauth2/authorization";
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+    @GetMapping("/auth/oauth/{provider}/login")
+    public RedirectView redirectToProvider(@PathVariable String provider) {
+
+        ClientRegistration registration = getClientRegistration(provider);
+        if (registration == null) {
+            return new RedirectView("/error?message=Unknown+provider");
+        }
+        String redirectUrl = OAUTH2_AUTHORIZATION_BASE_URI + "/" + provider;
+
+        return new RedirectView(redirectUrl);
+    }
+
+    private ClientRegistration getClientRegistration(String provider) {
+        if (clientRegistrationRepository instanceof Iterable) {
+            for (ClientRegistration registration : (Iterable<ClientRegistration>) clientRegistrationRepository) {
+                if (registration.getRegistrationId().equals(provider)) {
+                    return registration;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/auth/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,56 @@
+package com.samsamhajo.deepground.auth.oauth;
+
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = super.loadUser(userRequest);
+
+        try {
+            return this.process(userRequest, oauth2User);
+        } catch (Exception e) {
+            throw new OAuth2AuthenticationException(e.getMessage());
+        }
+    }
+
+    private OAuth2User process(OAuth2UserRequest userRequest, OAuth2User oauth2User) {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest
+                .getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.of(
+                registrationId,
+                userNameAttributeName,
+                oauth2User.getAttributes()
+        );
+
+        Member member = saveOrUpdate(attributes);
+
+        return new CustomUserDetails(member);
+    }
+
+    private Member saveOrUpdate(OAuthAttributes attributes) {
+        Member member = memberRepository.findByEmailAndProvider(attributes.getEmail(), attributes.getProvider())
+                .map(entity -> entity.update(attributes.getName()))
+                .orElse(attributes.toEntity());
+
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/auth/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,50 @@
+package com.samsamhajo.deepground.auth.oauth;
+
+import com.samsamhajo.deepground.auth.jwt.JwtProvider;
+import com.samsamhajo.deepground.auth.repository.RefreshTokenRepository;
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${app.oauth2.authorized-redirect-uri}")
+    private String oauth2RedirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String accessToken = jwtProvider.createAccessToken(userDetails.getMember().getId());
+        String refreshToken = jwtProvider.createRefreshToken(userDetails.getMember().getId());
+
+        refreshTokenRepository.save(userDetails.getMember().getId(), refreshToken, 1209600L);
+
+        String targetUrl = UriComponentsBuilder.fromUriString(oauth2RedirectUri)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .queryParam("email", userDetails.getMember().getEmail())
+                .queryParam("nickname", userDetails.getMember().getNickname())
+                .build()
+                .toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/auth/oauth/OAuthAttributes.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/oauth/OAuthAttributes.java
@@ -1,0 +1,90 @@
+package com.samsamhajo.deepground.auth.oauth;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.entity.Provider;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+    private final String name;
+    private final String email;
+    private final Provider provider;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes,
+                           String nameAttributeKey,
+                           String name,
+                           String email,
+                           Provider provider) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.provider = provider;
+    }
+
+    public static OAuthAttributes of(String registrationId,
+                                     String userNameAttributeName,
+                                     Map<String, Object> attributes) {
+        if ("kakao".equals(registrationId)) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+        if ("naver".equals(registrationId)) {
+            return ofNaver(userNameAttributeName, attributes);
+        }
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .provider(Provider.GOOGLE)
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        return OAuthAttributes.builder()
+                .name((String) kakaoProfile.get("nickname"))
+                .email((String) kakaoAccount.get("email"))
+                .provider(Provider.KAKAO)
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuthAttributes.builder()
+                .name((String) response.get("name"))
+                .email((String) response.get("email"))
+                .provider(Provider.NAVER)
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+
+    }
+
+    public Member toEntity() {
+        return Member.createSocialMember(
+                email,
+                name,
+                provider,
+                attributes.get(nameAttributeKey).toString()
+        );
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/samsamhajo/deepground/auth/security/CustomUserDetails.java
@@ -5,17 +5,26 @@ import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 @Getter
-public class CustomUserDetails implements UserDetails {
+public class CustomUserDetails implements UserDetails, OAuth2User {
 
     private final Member member;
+    private final Map<String, Object> attributes;
 
     public CustomUserDetails(Member member) {
         this.member = member;
+        this.attributes = Collections.emptyMap();
+    }
+
+    public CustomUserDetails(Member member, Map<String, Object> attributes){
+        this.member = member;
+        this.attributes = attributes;
     }
 
     @Override
@@ -53,5 +62,16 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    // 소셜 로그인
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return member.getEmail();
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
+++ b/src/main/java/com/samsamhajo/deepground/member/entity/Member.java
@@ -79,9 +79,16 @@ public class Member extends BaseEntity {
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
-        public void updateNickname (String nickname){
-            this.nickname = nickname;
-        }
+
+    public void updateNickname(String nickname){
+        this.nickname = nickname;
+    }
+
+    // 소셜 로그인 시 닉네임 동기화
+    public Member update(String nickname) {
+        this.nickname = nickname;
+        return this;
+    }
 }
 
 

--- a/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.member.repository;
 
 import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.entity.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,6 +16,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByEmailAndProvider(String email, Provider provider);
 
     String email(String email);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,48 @@ spring:
           auth: true
           starttls:
             enable: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/auth/oauth/google/callback"
+            scope:
+              - email
+              - profile
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: POST
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/auth/oauth/kakao/callback"
+            scope:
+              - profile_nickname
+              - account_email
+            provider: kakao
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            client-authentication-method: POST
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/auth/oauth/naver/callback"
+            scope:
+              - name
+              - email
+            provider: naver
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: id
 
 # JWT 설정
 jwt:
@@ -88,3 +130,8 @@ cors:
 swagger:
   server:
     url: ${SWAGGER_SERVER_URL:http://localhost:8080/api/v1}
+
+# OAuth 설정
+app:
+  oauth2:
+    authorized-redirect-uri: ${OAUTH2_AUTHORIZED_REDIRECT_URI}

--- a/src/test/java/com/samsamhajo/deepground/auth/oauth/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/auth/oauth/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,87 @@
+package com.samsamhajo.deepground.auth.oauth;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.entity.Provider;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class CustomOAuth2UserServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void 신규_소셜_회원이면_회원가입() {
+        // given
+        String email = "test@google.com";
+        String name = "테스트유저";
+        String registrationId = "google";
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", email);
+        attributes.put("name", name);
+
+        when(memberRepository.findByEmailAndProvider(email, Provider.GOOGLE))
+                .thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        customOAuth2UserService.createTestUserDetails(registrationId, attributes);
+
+        // then
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+        Member saved = memberCaptor.getValue();
+        assertThat(saved.getEmail()).isEqualTo(email);
+        assertThat(saved.getNickname()).isEqualTo(name);
+        assertThat(saved.getProvider()).isEqualTo(Provider.GOOGLE);
+        assertThat(saved.isVerified()).isTrue();
+    }
+
+    @Test
+    void 이미_가입된_회원이면_닉네임만_갱신() {
+        // given
+        String email = "test@google.com";
+        String oldName = "OldName";
+        String newName = "NewName";
+        String registrationId = "google";
+
+        Member oldMember = Member.createSocialMember(email, oldName, Provider.GOOGLE, "providerId");
+
+        when(memberRepository.findByEmailAndProvider(email, Provider.GOOGLE))
+                .thenReturn(Optional.of(oldMember));
+        when(memberRepository.save(any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", email);
+        attributes.put("name", newName);
+
+        // when
+        customOAuth2UserService.createTestUserDetails(registrationId, attributes);
+
+        // then
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+        Member updated = memberCaptor.getValue();
+        assertThat(updated.getNickname()).isEqualTo(newName);
+    }
+}


### PR DESCRIPTION
# 📌 개요

구글, 카카오, 네이버 등 소셜 로그인(OAuth2) 기능을 구현했습니다.


## 🛠️ 작업 내용

- OAuth2 소셜 로그인 통합
    - 구글/카카오/네이버 OAuth2 연동
    - Spring Security 기반 인증 플로우 적용
    - 각 provider별 사용자 정보 파싱 및 회원 엔티티 매핑
- 회원 정보 저장 및 동기화
    - 최초 로그인 시 신규 회원 자동 등록
    - 이미 가입된 경우 닉네임 등 정보 자동 업데이트
    - provider별(구글/카카오/네이버) 별도 관리
- JWT 발급 및 인증 처리
    - 소셜 로그인 성공 시 JWT(Access/Refresh Token) 발급
    - Access Token 만료 시 Refresh Token 통한 재발급 지원
- 콜백/리다이렉트 처리
    - Spring Security SuccessHandler에서 프론트엔드로 토큰 전달
    - redirect-uri 환경변수 및 소셜 콘솔 등록 일치 관리
- 테스트 코드 작성
    - 서비스 단위 테스트: 신규 회원, 정보 업데이트, provider별 파싱 등 검증
    - Mock/Mockito 기반 단위 테스트 및 통합 테스트


## 📌 소셜 로그인 플로우

1. 사용자가 소셜 로그인 버튼 클릭
2. Spring 서버가 provider별 인증 URL로 리다이렉트
3. 소셜 인증 서버에서 로그인/동의 후 콜백 URL로 code 전달
4. 서버가 code로 access token/refresh token 교환
5. 사용자 정보 파싱 후 회원 저장/업데이트
6. JWT 발급 및 프론트엔드로 리다이렉트

## 📌 테스트 결과
- 구글 

![image](https://github.com/user-attachments/assets/746d1a06-4c9f-4292-b2be-52054ebe36eb)
![image](https://github.com/user-attachments/assets/b47d03dd-a5de-4a7c-8f78-58a32a5f044d)
- 네이버

![image](https://github.com/user-attachments/assets/314be40f-94ad-40b8-8633-be23af6a8381)
![image](https://github.com/user-attachments/assets/23675a97-9e8d-4f47-ba47-dcc3db29e82e)


## 📌 테스트 케이스

- 구글/카카오/네이버 최초 로그인 시 회원 자동 등록되는지 확인
- 이미 가입된 소셜 회원이 로그인 시 닉네임 등 정보가 갱신되는지 확인


## 🙏🏻 PR 리뷰 가이드

- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀 규칙에 맞고 일관적인지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

