### PR TITLE
[Feature] 스터디 그룹 참여 멤버 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupMemberQueryController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupMemberQueryController.java
@@ -1,0 +1,33 @@
+package com.samsamhajo.deepground.studyGroup.controller;
+
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import com.samsamhajo.deepground.global.utils.GlobalLogger;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupMemberSummary;
+import com.samsamhajo.deepground.studyGroup.service.StudyGroupMemberQueryService;
+import com.samsamhajo.deepground.studyGroup.success.StudyGroupSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-group")
+public class StudyGroupMemberQueryController {
+
+  private final StudyGroupMemberQueryService queryService;
+
+  @GetMapping("/{studyGroupId}/members")
+  public ResponseEntity<SuccessResponse<List<StudyGroupMemberSummary>>> getStudyGroupMembers(
+      @PathVariable Long studyGroupId
+  ) {
+    GlobalLogger.info("스터디 참여자 목록 조회", studyGroupId);
+
+    List<StudyGroupMemberSummary> response = queryService.getAcceptedMembers(studyGroupId);
+
+    return ResponseEntity
+        .status(StudyGroupSuccessCode.READ_SUCCESS.getStatus())
+        .body(SuccessResponse.of(StudyGroupSuccessCode.READ_SUCCESS, response));
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupMemberSummary.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupMemberSummary.java
@@ -1,0 +1,15 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupMemberSummary {
+  private Long memberId;
+  private String nickname;
+  private boolean isOwner;
+  private LocalDateTime joinedAt;
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
@@ -23,6 +23,9 @@ public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMemb
   @Query("SELECT m FROM StudyGroupMember m JOIN FETCH m.member WHERE m.studyGroup.id = :studyGroupId")
   List<StudyGroupMember> findAllWithMemberByStudyGroupId(@Param("studyGroupId") Long studyGroupId);
 
+  @Query("SELECT m FROM StudyGroupMember m JOIN FETCH m.member WHERE m.studyGroup.id = :studyGroupId AND m.isAllowed = true ORDER BY m.createdAt ASC")
+  List<StudyGroupMember> findAcceptedMembersWithInfo(@Param("studyGroupId") Long studyGroupId);
+
   int countByStudyGroup_IdAndIsAllowedTrue(Long studyGroupId);
   int countByStudyGroup_IdAndIsAllowedFalse(Long studyGroupId);
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryService.java
@@ -1,0 +1,37 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupMemberSummary;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupMemberQueryService {
+
+  private final StudyGroupRepository studyGroupRepository;
+  private final StudyGroupMemberRepository studyGroupMemberRepository;
+
+  @Transactional
+  public List<StudyGroupMemberSummary> getAcceptedMembers(Long studyGroupId) {
+    StudyGroup group = studyGroupRepository.findById(studyGroupId)
+        .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
+
+    return studyGroupMemberRepository.findAcceptedMembersWithInfo(studyGroupId).stream()
+        .map(member -> StudyGroupMemberSummary.builder()
+            .memberId(member.getMember().getId())
+            .nickname(member.getMember().getNickname())
+            .isOwner(group.getMember().getId().equals(member.getMember().getId()))
+            .joinedAt(member.getCreatedAt())
+            .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryServiceTest.java
@@ -1,0 +1,63 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.IntegrationTestSupport;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.studyGroup.dto.StudyGroupMemberSummary;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StudyGroupMemberQueryServiceTest extends IntegrationTestSupport {
+
+  @Autowired private StudyGroupMemberQueryService queryService;
+  @Autowired private StudyGroupRepository studyGroupRepository;
+  @Autowired private StudyGroupMemberRepository studyGroupMemberRepository;
+  @Autowired private MemberRepository memberRepository;
+
+  private Member owner;
+  private Member memberA;
+  private StudyGroup group;
+
+  @BeforeEach
+  void setUp() {
+    owner = Member.createLocalMember("owner@test.com", "pw", "관리자");
+    memberA = Member.createLocalMember("user@test.com", "pw", "사용자");
+    memberRepository.save(owner);
+    memberRepository.save(memberA);
+
+    group = StudyGroup.of(
+        null, "테스트 스터디", "설명",
+        LocalDate.now(), LocalDate.now().plusDays(5),
+        LocalDate.now(), LocalDate.now().plusDays(1),
+        3, owner, true, "신촌"
+    );
+    studyGroupRepository.save(group);
+
+    StudyGroupMember memberOwner = StudyGroupMember.of(owner, group, true);
+    StudyGroupMember memberAJoined = StudyGroupMember.of(memberA, group, true);
+
+    studyGroupMemberRepository.save(memberOwner);
+    studyGroupMemberRepository.save(memberAJoined);
+  }
+
+  @Test
+  @DisplayName("스터디 수락된 멤버 목록을 조회한다")
+  void getAcceptedMembers() {
+    List<StudyGroupMemberSummary> members = queryService.getAcceptedMembers(group.getId());
+
+    assertThat(members).hasSize(2);
+    assertThat(members.get(0).getNickname()).isEqualTo("관리자");
+    assertThat(members.get(1).getNickname()).isEqualTo("사용자");
+  }
+}


### PR DESCRIPTION
## **📌 개요**

- 특정 스터디 그룹에 참여 중인 멤버들의 정보를 정렬하여 조회하는 기능을 추가했습니다.
- 스터디장의 권한 유무(isOwner)를 함께 반환하며, 수락된 멤버만 조회됩니다.
  

## **🛠️ 작업 내용**

- 수락된 스터디 그룹 멤버 조회 쿼리(JPQL) 추가
- 멤버 정보 요약 DTO(StudyGroupMemberSummary) 생성
- 서비스 계층에 참여 멤버 조회 기능 추가 (StudyGroupMemberQueryService)
- 컨트롤러 API 추가 (GET /study-group/{studyGroupId}/members)
- 통합 테스트 작성 (StudyGroupMemberQueryServiceTest)

### **참여자 정보 조회 기능 구현**

- 스터디 그룹 ID를 기준으로 수락된 멤버들을 참여일 순으로 정렬해 조회합니다.
- 각 멤버는 닉네임, 식별자, 참여일자, 스터디장 여부를 포함한 DTO로 응답됩니다.

### **테스트 케이스 구현**

- 참여자 2명을 설정한 뒤 API 호출을 통해 정렬, 데이터 정확성 검증
- 관리자, 사용자 각각 올바르게 매핑되었는지 확인

## **📌 차후 계획 (Optional)**

- 관리자만 전체 멤버 목록을 조회하도록 권한 제한 추가 예정
- 이메일, 전화번호 등 민감 정보 포함 여부를 설정값 또는 요청자 권한에 따라 제어하도록 개선 예정

## **📌 테스트 케이스**

- 기능 정상 동작 확인 (응답 필드, 순서, 예외 처리 등)
- 새로운 의존성 없음
- 코드 스타일 및 컨벤션 준수
- 기존 테스트 모두 통과

### **📌 기타 참고 사항**

- 팀원 간 리뷰 시 공개 범위 확정에 대한 논의가 필요합니다.
- isOwner 계산은 서비스 단에서 수행하며 성능에 부담을 주지 않습니다.
- DB 접근 최적화를 위해 JOIN FETCH 및 정렬 조건을 JPQL에 명시했습니다.

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #116