### PR TITLE
[Feature] 피드 답글 목록 조회하기

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedController.java
@@ -3,8 +3,8 @@ package com.samsamhajo.deepground.feed.feed.controller;
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.exception.FeedSuccessCode;
 import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
-import com.samsamhajo.deepground.feed.feed.model.FeedListResponse;
 import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
+import com.samsamhajo.deepground.feed.feed.model.FetchFeedsResponse;
 import com.samsamhajo.deepground.feed.feed.service.FeedService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -33,13 +33,13 @@ public class FeedController {
                 .ok(SuccessResponse.of(FeedSuccessCode.FEED_CREATED));
     }
 
-    @GetMapping
-    public ResponseEntity<SuccessResponse<FeedListResponse>> getFeeds(
+    @GetMapping("/list")
+    public ResponseEntity<SuccessResponse<FetchFeedsResponse>> getFeeds(
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        FeedListResponse feeds = feedService.getFeeds(pageable);
+        FetchFeedsResponse response = feedService.getFeeds(pageable, DEV_MEMBER_ID);
 
         return ResponseEntity
-                .ok(SuccessResponse.of(FeedSuccessCode.FEEDS_RETRIEVED, feeds));
+                .ok(SuccessResponse.of(FeedSuccessCode.FEED_LIST_FETCHED, response));
     }
     
     @PutMapping(value = "/{feedId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -55,7 +55,7 @@ public class FeedController {
     @DeleteMapping("/{feedId}")
     public ResponseEntity<SuccessResponse<Void>> deleteFeed(
             @PathVariable("feedId") Long feedId) {
-        feedService.deleteFeed(feedId, DEV_MEMBER_ID);
+        feedService.deleteFeed(feedId);
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedSuccessCode.FEED_DELETED));

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/exception/FeedSuccessCode.java
@@ -13,6 +13,7 @@ public enum FeedSuccessCode implements SuccessCode {
     FEED_MEDIA_UPDATED(HttpStatus.OK, "피드 미디어가 성공적으로 수정되었습니다."),
     FEED_LIKED(HttpStatus.OK, "피드가 성공적으로 좋아요 되었습니다."),
     FEED_UNLIKED(HttpStatus.OK, "피드 좋아요가 취소되었습니다."),
+    FEED_LIST_FETCHED(HttpStatus.OK, "피드 목록이 성공적으로 조회되었습니다.")
 
     ;
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/model/FetchFeedResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/model/FetchFeedResponse.java
@@ -1,5 +1,6 @@
-package com.samsamhajo.deepground.feed.feedcomment.model;
+package com.samsamhajo.deepground.feed.feed.model;
 
+import com.samsamhajo.deepground.feed.feedshared.model.FetchSharedFeedResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,17 +9,21 @@ import java.util.List;
 
 @Getter
 @Builder
-public class FetchFeedCommentResponse {
-
+public class FetchFeedResponse {
     private long memberId;
-    private long feedCommentId;
+    private long feedId;
     private String memberName;
     private String content;
-    private int replyCount;
     private int likeCount;
+
     private boolean isLiked;
+
+    private int commentCount;
+    private int shareCount;
     private int profileImageId;
     private LocalDate createdAt;
-
     private List<Long> mediaIds;
-}
+
+    private boolean isShared;
+    private FetchSharedFeedResponse sharedFeed;
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/model/FetchFeedsResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/model/FetchFeedsResponse.java
@@ -1,0 +1,18 @@
+package com.samsamhajo.deepground.feed.feed.model;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FetchFeedsResponse {
+    private List<FetchFeedResponse> feeds;
+
+    private FetchFeedsResponse(List<FetchFeedResponse> feeds) {
+        this.feeds = feeds;
+    }
+
+    public static FetchFeedsResponse of(List<FetchFeedResponse> feeds) {
+        return new FetchFeedsResponse(feeds);
+    }
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedLikeRepository.java
@@ -17,7 +17,7 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
 
     boolean existsByFeedIdAndMemberId(Long feedId, Long memberId);
 
-    List<FeedLike> findByFeedId(Long feedId);
+    void deleteAllByFeedId(Long feedId);
 
     Optional<FeedLike> findByFeedIdAndMemberId(Long feed, Long memberId);
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
@@ -50,6 +50,14 @@ public class FeedLikeService {
         return feedLikeRepository.countByFeedId(feedId);
     }
 
+    public void deleteAllByFeedId(Long feedId) {
+        feedLikeRepository.deleteAllByFeedId(feedId);
+    }
+
+    public boolean isLiked(Long feedId, Long memberId) {
+        return feedLikeRepository.existsByFeedIdAndMemberId(feedId, memberId);
+    }
+
     private void validateDecrease(Long feedId) {
         if(countFeedLikeByFeedId(feedId) <= 0){
             throw new FeedException(FeedErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED);

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -68,4 +68,11 @@ public class FeedMediaService {
             createFeedMedia(feed, request.getImages());
         }
     }
+
+    public List<Long> findAllMediaIdsByFeedId(Long feedId) {
+        return feedMediaRepository.findAllByFeedId(feedId)
+                .stream()
+                .map(FeedMedia::getId)
+                .toList();
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentController.java
@@ -3,6 +3,7 @@ package com.samsamhajo.deepground.feed.feedcomment.controller;
 import com.samsamhajo.deepground.feed.feedcomment.exception.FeedCommentSuccessCode;
 import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentCreateRequest;
 import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentUpdateRequest;
+import com.samsamhajo.deepground.feed.feedcomment.model.FetchFeedCommentsResponse;
 import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -50,10 +51,10 @@ public class FeedCommentController {
     }
 
     @GetMapping("/list/{feedId}")
-    public ResponseEntity<SuccessResponse<?>> getFeedComments(
+    public ResponseEntity<SuccessResponse<FetchFeedCommentsResponse>> getFeedComments(
             @PathVariable("feedId") Long feedId) {
 
-        var response = feedCommentService.getFeedComments(feedId);
+        FetchFeedCommentsResponse response = feedCommentService.getFeedComments(feedId, DEV_MEMBER_ID);
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedCommentSuccessCode.FEED_COMMENT_LIST_FETCHED, response));

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentMediaController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentMediaController.java
@@ -1,10 +1,10 @@
 package com.samsamhajo.deepground.feed.feedcomment.controller;
 
+import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentMediaResponse;
 import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentMediaService;
+import com.samsamhajo.deepground.media.MediaUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,12 +19,12 @@ public class FeedCommentMediaController {
     private final FeedCommentMediaService feedCommentMediaService;
 
     @GetMapping("/{mediaId}")
-    public ResponseEntity<InputStreamResource> getMedia(@PathVariable Long mediaId) {
-            InputStreamResource media = feedCommentMediaService.getMediaById(mediaId);
-            
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline")
-                    .contentType(MediaType.IMAGE_JPEG) // 기본값으로 JPEG 설정
-                    .body(media);
+    public ResponseEntity<InputStreamResource> viewImage(@PathVariable("mediaId") Long mediaId) {
+        FeedCommentMediaResponse feedCommentMediaResponse =
+                feedCommentMediaService.fetchFeedCommentMedia(mediaId);
+
+        return ResponseEntity.ok()
+                .contentType(MediaUtils.getMediaType(feedCommentMediaResponse.getExtension()))
+                .body(feedCommentMediaResponse.getImage());
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentMediaController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentMediaController.java
@@ -1,20 +1,19 @@
 package com.samsamhajo.deepground.feed.feedcomment.controller;
 
 import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentMediaService;
-import com.samsamhajo.deepground.media.MediaErrorCode;
-import com.samsamhajo.deepground.media.MediaException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/feed-comments/media")
+@RequestMapping("/feed/comment/media")
 public class FeedCommentMediaController {
 
     private final FeedCommentMediaService feedCommentMediaService;

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/model/FeedCommentMediaResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/model/FeedCommentMediaResponse.java
@@ -1,0 +1,19 @@
+package com.samsamhajo.deepground.feed.feedcomment.model;
+
+import lombok.Getter;
+import org.springframework.core.io.InputStreamResource;
+
+@Getter
+public class FeedCommentMediaResponse {
+    private final InputStreamResource image;
+    private final String extension;
+
+    private FeedCommentMediaResponse(InputStreamResource image, String extension) {
+        this.image = image;
+        this.extension = extension;
+    }
+
+    public static FeedCommentMediaResponse of(InputStreamResource image, String extension) {
+        return new FeedCommentMediaResponse(image, extension);
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/repository/FeedCommentRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/repository/FeedCommentRepository.java
@@ -13,6 +13,7 @@ public interface FeedCommentRepository extends JpaRepository<FeedComment, Long> 
     default FeedComment getById(Long feedCommentId) {
         return findById(feedCommentId).orElseThrow(() -> new FeedCommentException(FeedCommentErrorCode.FEED_COMMENT_NOT_FOUND));
     }
-
     List<FeedComment> findAllByFeedId(Long feedId);
+
+    int countByFeedId(Long feedId);
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentLikeService.java
@@ -54,6 +54,10 @@ public class FeedCommentLikeService {
         feedCommentLikeRepository.deleteAllByFeedCommentId(feedCommentId);
     }
 
+    public boolean isLiked(Long feedCommentId, Long memberId) {
+        return feedCommentLikeRepository.existsByFeedCommentIdAndMemberId(feedCommentId, memberId);
+    }
+
     private void validateDecrease(Long feedId) {
         if (countFeedCommentLikeByFeedId(feedId) <= 0) {
             throw new FeedCommentException(FeedCommentErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED);

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentMediaService.java
@@ -2,6 +2,7 @@ package com.samsamhajo.deepground.feed.feedcomment.service;
 
 import com.samsamhajo.deepground.feed.feedcomment.entity.FeedComment;
 import com.samsamhajo.deepground.feed.feedcomment.entity.FeedCommentMedia;
+import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentMediaResponse;
 import com.samsamhajo.deepground.feed.feedcomment.repository.FeedCommentMediaRepository;
 import com.samsamhajo.deepground.media.MediaErrorCode;
 import com.samsamhajo.deepground.media.MediaException;
@@ -13,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -37,6 +37,30 @@ public class FeedCommentMediaService {
         );
     }
 
+    public List<FeedCommentMedia> findAllByFeedComment(FeedComment feedComment) {
+        return feedCommentMediaRepository.findAllByFeedCommentId(feedComment.getId());
+    }
+
+    public FeedCommentMediaResponse fetchFeedCommentMedia(Long feedCommentMediaId) {
+        FeedCommentMedia feedCommentMedia = feedCommentMediaRepository.findById(feedCommentMediaId)
+                .orElseThrow(() -> new MediaException(MediaErrorCode.MEDIA_NOT_FOUND));
+        InputStreamResource media = MediaUtils.getMedia(feedCommentMedia.getMediaUrl());
+
+        return FeedCommentMediaResponse.of(media, feedCommentMedia.getExtension());
+    }
+
+    @Transactional
+    public void deleteAllByFeedCommentId(Long feedCommentId) {
+        // 파일 시스템에서 물리적 미디어 파일 삭제
+        List<FeedCommentMedia> mediaList = feedCommentMediaRepository.findAllByFeedCommentId(feedCommentId);
+        for (FeedCommentMedia media : mediaList) {
+            MediaUtils.deleteMedia(media.getMediaUrl());
+        }
+        
+        // DB에서 삭제 (JPA Query Method 사용)
+        feedCommentMediaRepository.deleteAllByFeedCommentId(feedCommentId);
+    }
+
     public List<Long> getFeedCommentMediaIds(Long feedCommentId) {
         return feedCommentMediaRepository.findAllByFeedCommentId(feedCommentId)
                 .stream()
@@ -45,33 +69,12 @@ public class FeedCommentMediaService {
     }
 
     public void updateFeedCommentMedia(FeedComment feedComment, List<MultipartFile> images) {
-        if (CollectionUtils.isEmpty(images)) return;
-
-        // 피드 댓글에에 연결된 모든 미디어 삭제
+        // 피드 댓글에 연결된 모든 미디어 삭제
         deleteAllByFeedCommentId(feedComment.getId());
 
         // 새 미디어 추가
-        createFeedCommentMedia(feedComment, images);
-    }
-
-    @Transactional
-    public void deleteAllByFeedCommentId(Long feedCommentId) {
-        // 파일 시스템에서 물리적 미디어 파일 삭제
-        List<FeedCommentMedia> mediaList = feedCommentMediaRepository.findAllByFeedCommentId(feedCommentId);
-
-        for (FeedCommentMedia media : mediaList) {
-            MediaUtils.deleteMedia(media.getMediaUrl());
+        if (images != null && !images.isEmpty()) {
+            createFeedCommentMedia(feedComment, images);
         }
-
-        // DB에서 삭제 (JPA Query Method 사용)
-        feedCommentMediaRepository.deleteAllByFeedCommentId(feedCommentId);
     }
-
-    public InputStreamResource getMediaById(Long mediaId) {
-        FeedCommentMedia media = feedCommentMediaRepository.findById(mediaId)
-                .orElseThrow(() -> new MediaException(MediaErrorCode.MEDIA_NOT_FOUND));
-
-        return MediaUtils.getMedia(media.getMediaUrl());
-    }
-
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentService.java
@@ -90,7 +90,7 @@ public class FeedCommentService {
         feedCommentRepository.deleteAll(feedComments);
     }
 
-    public FetchFeedCommentsResponse getFeedComments(Long feedId) {
+    public FetchFeedCommentsResponse getFeedComments(Long feedId, Long memberId) {
         return FetchFeedCommentsResponse.of(
                 feedCommentRepository.findAllByFeedId(feedId).stream()
                         .map(feedComment -> FetchFeedCommentResponse.builder()
@@ -102,7 +102,12 @@ public class FeedCommentService {
                                 .mediaIds(feedCommentMediaService.getFeedCommentMediaIds(feedComment.getId()))
                                 .replyCount(feedReplyService.countFeedRepliesByFeedCommentId(feedComment.getId()))
                                 .likeCount(feedCommentLikeService.countFeedCommentLikeByFeedId(feedComment.getId()))
+                                .isLiked(feedCommentLikeService.isLiked(feedComment.getId(),memberId))
                                 .build()).toList());
+    }
+
+    public int countFeedCommentsByFeedId(Long feedId) {
+        return feedCommentRepository.countByFeedId(feedId);
     }
 
     private void deleteAllRelatedEntities(Long feedCommentId) {

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
@@ -54,7 +54,7 @@ public class FeedReplyController {
     public ResponseEntity<SuccessResponse<?>> getFeedReplies(
             @PathVariable("feedReplyId") Long feedCommentId) {
 
-        FetchFeedRepliesResponse response = feedReplyService.getFeedReplies(feedCommentId);
+        FetchFeedRepliesResponse response = feedReplyService.getFeedReplies(feedCommentId, DEV_MEMBER_ID);
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_LIST_FETCHED, response));

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
@@ -50,9 +50,9 @@ public class FeedReplyController {
                 .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_DELETED));
     }
 
-    @GetMapping("/list/{feedCommentId}")
+    @GetMapping("/list/{feedReplyId}")
     public ResponseEntity<SuccessResponse<?>> getFeedReplies(
-            @PathVariable("feedCommentId") Long feedCommentId) {
+            @PathVariable("feedReplyId") Long feedCommentId) {
 
         FetchFeedRepliesResponse response = feedReplyService.getFeedReplies(feedCommentId);
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
@@ -3,6 +3,7 @@ package com.samsamhajo.deepground.feed.feedreply.controller;
 import com.samsamhajo.deepground.feed.feedreply.exception.FeedReplySuccessCode;
 import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyCreateRequest;
 import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyUpdateRequest;
+import com.samsamhajo.deepground.feed.feedreply.model.FetchFeedRepliesResponse;
 import com.samsamhajo.deepground.feed.feedreply.service.FeedReplyService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -47,5 +48,15 @@ public class FeedReplyController {
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_DELETED));
+    }
+
+    @GetMapping("/list/{feedCommentId}")
+    public ResponseEntity<SuccessResponse<?>> getFeedReplies(
+            @PathVariable("feedCommentId") Long feedCommentId) {
+
+        FetchFeedRepliesResponse response = feedReplyService.getFeedReplies(feedCommentId);
+
+        return ResponseEntity
+                .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_LIST_FETCHED, response));
     }
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyMediaController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyMediaController.java
@@ -1,30 +1,26 @@
 package com.samsamhajo.deepground.feed.feedreply.controller;
 
-import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentMediaService;
+import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyMediaResponse;
+import com.samsamhajo.deepground.feed.feedreply.service.FeedReplyMediaService;
+import com.samsamhajo.deepground.media.MediaUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/feed/reply/media")
 public class FeedReplyMediaController {
 
-    private final FeedCommentMediaService feedCommentMediaService;
+    private final FeedReplyMediaService feedReplyMediaService;
 
     @GetMapping("/{mediaId}")
-    public ResponseEntity<InputStreamResource> getMedia(@PathVariable Long mediaId) {
-            InputStreamResource media = feedCommentMediaService.getMediaById(mediaId);
-            
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline")
-                    .contentType(MediaType.IMAGE_JPEG) // 기본값으로 JPEG 설정
-                    .body(media);
+    public ResponseEntity<InputStreamResource> viewImage(@PathVariable Long mediaId) {
+        FeedReplyMediaResponse response = feedReplyMediaService.fetchFeedReplyMedia(mediaId);
+        
+        return ResponseEntity.ok()
+                .contentType(MediaUtils.getMediaType(response.getExtension()))
+                .body(response.getImage());
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyMediaController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyMediaController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/feed/comment/media")
+@RequestMapping("/feed/reply/media")
 public class FeedReplyMediaController {
 
     private final FeedCommentMediaService feedCommentMediaService;

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyMediaController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyMediaController.java
@@ -1,0 +1,30 @@
+package com.samsamhajo.deepground.feed.feedreply.controller;
+
+import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentMediaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/feed/comment/media")
+public class FeedReplyMediaController {
+
+    private final FeedCommentMediaService feedCommentMediaService;
+
+    @GetMapping("/{mediaId}")
+    public ResponseEntity<InputStreamResource> getMedia(@PathVariable Long mediaId) {
+            InputStreamResource media = feedCommentMediaService.getMediaById(mediaId);
+            
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline")
+                    .contentType(MediaType.IMAGE_JPEG) // 기본값으로 JPEG 설정
+                    .body(media);
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/exception/FeedReplySuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/exception/FeedReplySuccessCode.java
@@ -12,7 +12,8 @@ public enum FeedReplySuccessCode implements SuccessCode {
     FEED_REPLY_UPDATED(HttpStatus.OK, "답글이 수정되었습니다."),
     FEED_REPLY_LIKED(HttpStatus.OK, "답글이 좋아요 되었습니다."),
     FEED_REPLY_DISLIKED(HttpStatus.OK, "답글 좋아요가 취소되었습니다."),
-    FEED_REPLY_DELETED(HttpStatus.OK, "답글이 삭제되었습니다.")
+    FEED_REPLY_DELETED(HttpStatus.OK, "답글이 삭제되었습니다."),
+    FEED_REPLY_LIST_FETCHED(HttpStatus.OK, "답글 목록이 조회되었습니다."),
 
     ;
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/model/FeedReplyMediaResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/model/FeedReplyMediaResponse.java
@@ -1,0 +1,19 @@
+package com.samsamhajo.deepground.feed.feedreply.model;
+
+import lombok.Getter;
+import org.springframework.core.io.InputStreamResource;
+
+@Getter
+public class FeedReplyMediaResponse {
+    private final InputStreamResource image;
+    private final String extension;
+
+    private FeedReplyMediaResponse(InputStreamResource image, String extension) {
+        this.image = image;
+        this.extension = extension;
+    }
+
+    public static FeedReplyMediaResponse of(InputStreamResource image, String extension) {
+        return new FeedReplyMediaResponse(image, extension);
+    }
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/model/FetchFeedRepliesResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/model/FetchFeedRepliesResponse.java
@@ -1,0 +1,18 @@
+package com.samsamhajo.deepground.feed.feedreply.model;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FetchFeedRepliesResponse {
+    private List<FetchFeedReplyResponse> feedReplies;
+
+    private FetchFeedRepliesResponse(List<FetchFeedReplyResponse> feedReplies) {
+        this.feedReplies = feedReplies;
+    }
+
+    public static FetchFeedRepliesResponse of(List<FetchFeedReplyResponse> feedReplies) {
+        return new FetchFeedRepliesResponse(feedReplies);
+    }
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/model/FetchFeedReplyResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/model/FetchFeedReplyResponse.java
@@ -1,0 +1,20 @@
+package com.samsamhajo.deepground.feed.feedreply.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class FetchFeedReplyResponse {
+    private long memberId;
+    private long feedReplyId;
+    private String memberName;
+    private String content;
+    private int likeCount;
+    private int profileImageId;
+    private LocalDate createdAt;
+    private List<Long> mediaIds;
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/model/FetchFeedReplyResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/model/FetchFeedReplyResponse.java
@@ -15,6 +15,7 @@ public class FetchFeedReplyResponse {
     private String content;
     private int likeCount;
     private int profileImageId;
+    private boolean isLiked;
     private LocalDate createdAt;
     private List<Long> mediaIds;
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyLikeService.java
@@ -52,6 +52,10 @@ public class FeedReplyLikeService {
         feedReplyLikeRepository.deleteAllByFeedReplyId(feedReplyId);
     }
 
+    public boolean isLiked(Long feedReplyId, Long memberId) {
+        return feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(feedReplyId, memberId);
+    }
+
     private void validateDecrease(Long feedReplyId) {
         if (countFeedReplyLikeByFeedReplyId(feedReplyId) <= 0) {
             throw new FeedReplyException(FeedReplyErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED);

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyMediaService.java
@@ -5,10 +5,10 @@ import com.samsamhajo.deepground.feed.feedreply.entity.FeedReplyMedia;
 import com.samsamhajo.deepground.feed.feedreply.repository.FeedReplyMediaRepository;
 import com.samsamhajo.deepground.media.MediaUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
@@ -54,5 +54,12 @@ public class FeedReplyMediaService {
 
         // 새 미디어 추가
         createFeedReplyMedia(feedReply, images);
+    }
+
+    public List<Long> getFeedReplyMediaIds(Long feedReplyId) {
+        return feedReplyMediaRepository.findAllByFeedReplyId(feedReplyId)
+                .stream()
+                .map(FeedReplyMedia::getId)
+                .toList();
     }
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyMediaService.java
@@ -2,13 +2,17 @@ package com.samsamhajo.deepground.feed.feedreply.service;
 
 import com.samsamhajo.deepground.feed.feedreply.entity.FeedReply;
 import com.samsamhajo.deepground.feed.feedreply.entity.FeedReplyMedia;
+import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyMediaResponse;
 import com.samsamhajo.deepground.feed.feedreply.repository.FeedReplyMediaRepository;
+import com.samsamhajo.deepground.media.MediaErrorCode;
+import com.samsamhajo.deepground.media.MediaException;
 import com.samsamhajo.deepground.media.MediaUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 
@@ -61,5 +65,13 @@ public class FeedReplyMediaService {
                 .stream()
                 .map(FeedReplyMedia::getId)
                 .toList();
+    }
+
+    public FeedReplyMediaResponse fetchFeedReplyMedia(Long mediaId) {
+        FeedReplyMedia media = feedReplyMediaRepository.findById(mediaId)
+                .orElseThrow(() -> new MediaException(MediaErrorCode.MEDIA_NOT_FOUND));
+
+        InputStreamResource image = MediaUtils.getMedia(media.getMediaUrl());
+        return FeedReplyMediaResponse.of(image, media.getExtension());
     }
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
@@ -9,6 +9,8 @@ import com.samsamhajo.deepground.feed.feedreply.exception.FeedReplyErrorCode;
 import com.samsamhajo.deepground.feed.feedreply.exception.FeedReplyException;
 import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyCreateRequest;
 import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyUpdateRequest;
+import com.samsamhajo.deepground.feed.feedreply.model.FetchFeedRepliesResponse;
+import com.samsamhajo.deepground.feed.feedreply.model.FetchFeedReplyResponse;
 import com.samsamhajo.deepground.feed.feedreply.repository.FeedReplyRepository;
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.exception.MemberErrorCode;
@@ -103,5 +105,19 @@ public class FeedReplyService {
 
     private void saveFeedReplyMedia(FeedReplyCreateRequest request, FeedReply feedReply) {
         feedReplyMediaService.createFeedReplyMedia(feedReply, request.getImages());
+    }
+
+    public FetchFeedRepliesResponse getFeedReplies(Long feedCommentId) {
+        return FetchFeedRepliesResponse.of(
+                feedReplyRepository.findAllByFeedCommentId(feedCommentId).stream()
+                        .map(feedReply -> FetchFeedReplyResponse.builder()
+                                .feedReplyId(feedReply.getId())
+                                .content(feedReply.getContent())
+                                .createdAt(feedReply.getCreatedAt().toLocalDate())
+                                .memberId(feedReply.getMember().getId())
+                                .memberName(feedReply.getMember().getNickname())
+                                .mediaIds(feedReplyMediaService.getFeedReplyMediaIds(feedReply.getId()))
+                                .likeCount(feedReplyLikeService.countFeedReplyLikeByFeedReplyId(feedReply.getId()))
+                                .build()).toList());
     }
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
@@ -107,7 +107,7 @@ public class FeedReplyService {
         feedReplyMediaService.createFeedReplyMedia(feedReply, request.getImages());
     }
 
-    public FetchFeedRepliesResponse getFeedReplies(Long feedCommentId) {
+    public FetchFeedRepliesResponse getFeedReplies(Long feedCommentId, Long memberId) {
         return FetchFeedRepliesResponse.of(
                 feedReplyRepository.findAllByFeedCommentId(feedCommentId).stream()
                         .map(feedReply -> FetchFeedReplyResponse.builder()
@@ -118,6 +118,7 @@ public class FeedReplyService {
                                 .memberName(feedReply.getMember().getNickname())
                                 .mediaIds(feedReplyMediaService.getFeedReplyMediaIds(feedReply.getId()))
                                 .likeCount(feedReplyLikeService.countFeedReplyLikeByFeedReplyId(feedReply.getId()))
+                                .isLiked(feedReplyLikeService.isLiked(feedReply.getId(), memberId))
                                 .build()).toList());
     }
 } 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/controller/SharedFeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/controller/SharedFeedController.java
@@ -1,0 +1,27 @@
+package com.samsamhajo.deepground.feed.feedshared.controller;
+
+import com.samsamhajo.deepground.feed.feedshared.dto.SharedFeedRequest;
+import com.samsamhajo.deepground.feed.feedshared.exception.SharedFeedSuccessCode;
+import com.samsamhajo.deepground.feed.feedshared.service.SharedFeedService;
+import com.samsamhajo.deepground.global.success.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/feed/share")
+public class SharedFeedController {
+
+    private final SharedFeedService sharedFeedService;
+    private final Long DEV_MEMBER_ID = 1L;
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createSharedFeed(
+            @Valid @RequestBody SharedFeedRequest request) {
+
+        sharedFeedService.createSharedFeed(request, DEV_MEMBER_ID);
+        
+        return ResponseEntity.ok(SuccessResponse.of(SharedFeedSuccessCode.FEED_SHARED));
+    }
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/dto/SharedFeedRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/dto/SharedFeedRequest.java
@@ -1,0 +1,16 @@
+package com.samsamhajo.deepground.feed.feedshared.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SharedFeedRequest {
+    @NotNull(message = "원본 피드 ID는 필수입니다.")
+    private Long originFeedId;
+
+    private String content;
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/exception/SharedFeedErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/exception/SharedFeedErrorCode.java
@@ -1,0 +1,16 @@
+package com.samsamhajo.deepground.feed.feedshared.exception;
+
+import com.samsamhajo.deepground.global.error.core.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SharedFeedErrorCode implements ErrorCode {
+    SHARED_FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "공유된 피드를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/exception/SharedFeedException.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/exception/SharedFeedException.java
@@ -1,0 +1,9 @@
+package com.samsamhajo.deepground.feed.feedshared.exception;
+
+import com.samsamhajo.deepground.global.error.core.BaseException;
+
+public class SharedFeedException extends BaseException {
+    public SharedFeedException(SharedFeedErrorCode errorCode) {
+        super(errorCode);
+    }
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/exception/SharedFeedSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/exception/SharedFeedSuccessCode.java
@@ -1,0 +1,17 @@
+package com.samsamhajo.deepground.feed.feedshared.exception;
+
+import com.samsamhajo.deepground.global.success.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SharedFeedSuccessCode implements SuccessCode {
+    FEED_SHARED(HttpStatus.CREATED, "피드가 공유 되었습니다."),
+
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/model/FetchSharedFeedResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/model/FetchSharedFeedResponse.java
@@ -1,0 +1,35 @@
+package com.samsamhajo.deepground.feed.feedshared.model;
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.feed.feedshared.entity.SharedFeed;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class FetchSharedFeedResponse {
+    private long feedId;
+    private long memberId;
+    private String memberName;
+    private String content;
+    private int profileImageId;
+    private LocalDate createdAt;
+    private List<Long> mediaIds;
+
+
+    public static FetchSharedFeedResponse toDto(SharedFeed sharedFeed, List<Long> mediaIds) {
+        Feed originFeed = sharedFeed.getOriginFeed();
+
+        return FetchSharedFeedResponse.builder()
+                .feedId(originFeed.getId())
+                .memberId(originFeed.getMember().getId())
+                .memberName(originFeed.getMember().getNickname())
+                .content(originFeed.getContent())
+                .createdAt(originFeed.getCreatedAt().toLocalDate())
+                .mediaIds(mediaIds)
+                .build();
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/repository/SharedFeedRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/repository/SharedFeedRepository.java
@@ -1,0 +1,25 @@
+package com.samsamhajo.deepground.feed.feedshared.repository;
+
+import com.samsamhajo.deepground.feed.feedshared.entity.SharedFeed;
+import com.samsamhajo.deepground.feed.feedshared.exception.SharedFeedErrorCode;
+import com.samsamhajo.deepground.feed.feedshared.exception.SharedFeedException;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SharedFeedRepository extends JpaRepository<SharedFeed, Long> {
+
+    int countAllByOriginFeedId(Long originFeedId);
+
+    Optional<SharedFeed> findByFeedId(Long feedId);
+
+    default SharedFeed getByFeedId(Long feedId){
+        return findByFeedId(feedId)
+                .orElseThrow(() -> new SharedFeedException(SharedFeedErrorCode.SHARED_FEED_NOT_FOUND));
+    }
+
+    default SharedFeed getOrNullByFeedId(Long feedId){
+        return findByFeedId(feedId).orElse(null);
+    }
+} 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/service/SharedFeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/service/SharedFeedService.java
@@ -1,0 +1,69 @@
+package com.samsamhajo.deepground.feed.feedshared.service;
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.feed.feedshared.model.FetchSharedFeedResponse;
+import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
+import com.samsamhajo.deepground.feed.feed.service.FeedMediaService;
+import com.samsamhajo.deepground.feed.feedshared.dto.SharedFeedRequest;
+import com.samsamhajo.deepground.feed.feedshared.entity.SharedFeed;
+import com.samsamhajo.deepground.feed.feedshared.repository.SharedFeedRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.exception.MemberErrorCode;
+import com.samsamhajo.deepground.member.exception.MemberException;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SharedFeedService {
+
+    private final SharedFeedRepository sharedFeedRepository;
+    private final FeedRepository feedRepository;
+    private final MemberRepository memberRepository;
+    private final FeedMediaService feedMediaService;
+
+    @Transactional
+    public SharedFeed createSharedFeed(SharedFeedRequest request, Long memberId) {
+        Feed originFeed = feedRepository.getById(request.getOriginFeedId());
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
+
+        Feed feed = Feed.of(request.getContent(), member);
+        feedRepository.save(feed);
+
+        SharedFeed sharedFeed = SharedFeed.of(feed, originFeed, member);
+        sharedFeedRepository.save(sharedFeed);
+        
+        return sharedFeed;
+    }
+
+    public FetchSharedFeedResponse getSharedFeedResponse(Long feedId){
+        SharedFeed sharedFeed = findOrNullByFeedId(feedId);
+
+        if(sharedFeed == null){
+            return null;
+        }
+
+        List<Long> sharedFeedMediaIds =
+                feedMediaService.findAllMediaIdsByFeedId(sharedFeed.getOriginFeed().getId());
+
+        return FetchSharedFeedResponse.toDto(sharedFeed, sharedFeedMediaIds);
+    }
+
+    public int countSharedFeedByOriginFeedId(Long originFeedId) {
+        return sharedFeedRepository.countAllByOriginFeedId(originFeedId);
+    }
+
+    public SharedFeed findByFeedId(Long feedId) {
+        return sharedFeedRepository.getByFeedId(feedId);
+    }
+
+    public SharedFeed findOrNullByFeedId(Long feedId) {
+        return sharedFeedRepository.getOrNullByFeedId(feedId);
+    }
+} 

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeServiceTest.java
@@ -10,134 +10,176 @@ import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.exception.MemberErrorCode;
 import com.samsamhajo.deepground.member.exception.MemberException;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
 class FeedLikeServiceTest {
 
-    @InjectMocks
+    private FeedRepository feedRepository;
+    private MemberRepository memberRepository;
+    private FeedLikeRepository feedLikeRepository;
     private FeedLikeService feedLikeService;
 
-    @Mock
-    private FeedRepository feedRepository;
+    private static final String TEST_CONTENT = "테스트 피드 내용입니다.";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "테스트유저";
 
-    @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
-    private FeedLikeRepository feedLikeRepository;
-
-    private final Member member = Member.createLocalMember("test@naver.com", "password", "testUser");
-    private final Feed feed = Feed.of("테스트 피드 내용", member);
-
-    @Test
-    @DisplayName("피드 좋아요 증가 성공 테스트")
-    void feedLikeIncrease_Success() {
-        // given
-        Long feedId = 1L;
-        Long memberId = 1L;
-
-        given(feedRepository.getById(feedId)).willReturn(feed);
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(feedLikeRepository.existsByFeedIdAndMemberId(feedId, memberId)).willReturn(false);
-
-        // when
-        feedLikeService.feedLikeIncrease(feedId, memberId);
-
-        // then
-        verify(feedLikeRepository, times(1)).save(any(FeedLike.class));
+    @BeforeEach
+    void setUp() {
+        feedRepository = mock(FeedRepository.class);
+        memberRepository = mock(MemberRepository.class);
+        feedLikeRepository = mock(FeedLikeRepository.class);
+        
+        feedLikeService = new FeedLikeService(
+            feedRepository,
+            memberRepository,
+            feedLikeRepository
+        );
     }
 
     @Test
-    @DisplayName("피드 좋아요 증가 실패 테스트 - 이미 좋아요한 경우")
-    void feedLikeIncrease_Fail_AlreadyLiked() {
+    @DisplayName("피드 좋아요 증가 성공")
+    void feedLikeIncreaseSuccess() {
         // given
-        Long feedId = 1L;
-        Long memberId = 1L;
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed testFeed = Feed.of(TEST_CONTENT, testMember);
+        FeedLike feedLike = FeedLike.of(testFeed, testMember);
 
-        given(feedLikeRepository.existsByFeedIdAndMemberId(feedId, memberId)).willReturn(true);
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(testFeed, "id", 1L);
+        ReflectionTestUtils.setField(feedLike, "id", 1L);
+
+        when(feedRepository.getById(1L)).thenReturn(testFeed);
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(feedLikeRepository.existsByFeedIdAndMemberId(1L, 1L)).thenReturn(false);
+        when(feedLikeRepository.save(any(FeedLike.class))).thenReturn(feedLike);
+
+        // when
+        feedLikeService.feedLikeIncrease(1L, 1L);
+
+        // then
+        verify(feedLikeRepository).save(any(FeedLike.class));
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 증가 실패 - 이미 좋아요를 누른 경우")
+    void feedLikeIncreaseFailWithAlreadyLiked() {
+        // given
+        when(feedLikeRepository.existsByFeedIdAndMemberId(1L, 1L)).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> feedLikeService.feedLikeIncrease(feedId, memberId))
+        assertThatThrownBy(() -> feedLikeService.feedLikeIncrease(1L, 1L))
                 .isInstanceOf(FeedException.class)
                 .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_LIKE_ALREADY_EXISTS);
     }
 
     @Test
-    @DisplayName("피드 좋아요 증가 실패 테스트 - 존재하지 않는 회원")
-    void feedLikeIncrease_Fail_MemberNotFound() {
+    @DisplayName("피드 좋아요 증가 실패 - 존재하지 않는 회원")
+    void feedLikeIncreaseFailWithInvalidMember() {
         // given
-        Long feedId = 1L;
-        Long nonExistentMemberId = 999L;
-
-        given(feedLikeRepository.existsByFeedIdAndMemberId(feedId, nonExistentMemberId)).willReturn(false);
-        given(memberRepository.findById(nonExistentMemberId)).willReturn(Optional.empty());
+        when(feedLikeRepository.existsByFeedIdAndMemberId(1L, 1L)).thenReturn(false);
+        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> feedLikeService.feedLikeIncrease(feedId, nonExistentMemberId))
+        assertThatThrownBy(() -> feedLikeService.feedLikeIncrease(1L, 1L))
                 .isInstanceOf(MemberException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
     }
 
     @Test
-    @DisplayName("피드 좋아요 감소 성공 테스트")
-    void feedLikeDecrease_Success() {
+    @DisplayName("피드 좋아요 감소 성공")
+    void feedLikeDecreaseSuccess() {
         // given
-        Long feedId = 1L;
-        Long memberId = 1L;
-        FeedLike feedLike = FeedLike.of(feed, member);
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed testFeed = Feed.of(TEST_CONTENT, testMember);
+        FeedLike feedLike = FeedLike.of(testFeed, testMember);
 
-        given(feedLikeRepository.countByFeedId(feedId)).willReturn(1);
-        given(feedLikeRepository.getByFeedIdAndMemberId(feedId, memberId)).willReturn(feedLike);
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(testFeed, "id", 1L);
+        ReflectionTestUtils.setField(feedLike, "id", 1L);
+
+        when(feedLikeRepository.countByFeedId(1L)).thenReturn(1);
+        when(feedLikeRepository.getByFeedIdAndMemberId(1L, 1L)).thenReturn(feedLike);
 
         // when
-        feedLikeService.feedLikeDecrease(feedId, memberId);
+        feedLikeService.feedLikeDecrease(1L, 1L);
 
         // then
-        verify(feedLikeRepository, times(1)).delete(feedLike);
+        verify(feedLikeRepository).delete(feedLike);
     }
 
     @Test
-    @DisplayName("피드 좋아요 감소 실패 테스트 - 좋아요가 없는 경우")
-    void feedLikeDecrease_Fail_NoLikes() {
+    @DisplayName("피드 좋아요 감소 실패 - 좋아요가 없는 경우")
+    void feedLikeDecreaseFailWithNoLike() {
         // given
-        Long feedId = 1L;
-        Long memberId = 1L;
-
-        given(feedLikeRepository.countByFeedId(feedId)).willReturn(0);
+        when(feedLikeRepository.countByFeedId(1L)).thenReturn(0);
 
         // when & then
-        assertThatThrownBy(() -> feedLikeService.feedLikeDecrease(feedId, memberId))
+        assertThatThrownBy(() -> feedLikeService.feedLikeDecrease(1L, 1L))
                 .isInstanceOf(FeedException.class)
                 .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED);
     }
 
     @Test
-    @DisplayName("피드 좋아요 수 조회 테스트")
-    void countFeedLikeByFeedId_Success() {
+    @DisplayName("피드 좋아요 감소 실패 - 존재하지 않는 좋아요")
+    void feedLikeDecreaseFailWithInvalidLike() {
         // given
-        Long feedId = 1L;
-        int expectedCount = 5;
+        when(feedLikeRepository.countByFeedId(1L)).thenReturn(1);
+        when(feedLikeRepository.getByFeedIdAndMemberId(1L, 1L))
+                .thenThrow(new FeedException(FeedErrorCode.FEED_LIKE_NOT_FOUND));
 
-        given(feedLikeRepository.countByFeedId(feedId)).willReturn(expectedCount);
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.feedLikeDecrease(1L, 1L))
+                .isInstanceOf(FeedException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_LIKE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 수 조회 성공")
+    void countFeedLikeByFeedIdSuccess() {
+        // given
+        when(feedLikeRepository.countByFeedId(1L)).thenReturn(5);
 
         // when
-        int actualCount = feedLikeService.countFeedLikeByFeedId(feedId);
+        int count = feedLikeService.countFeedLikeByFeedId(1L);
 
         // then
-        assertThat(actualCount).isEqualTo(expectedCount);
+        assertThat(count).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 여부 확인 성공")
+    void isLikedSuccess() {
+        // given
+        when(feedLikeRepository.existsByFeedIdAndMemberId(1L, 1L)).thenReturn(true);
+
+        // when
+        boolean isLiked = feedLikeService.isLiked(1L, 1L);
+
+        // then
+        assertThat(isLiked).isTrue();
+    }
+
+    @Test
+    @DisplayName("피드의 모든 좋아요 삭제 성공")
+    void deleteAllByFeedIdSuccess() {
+        // given
+        Long feedId = 1L;
+
+        // when
+        feedLikeService.deleteAllByFeedId(feedId);
+
+        // then
+        verify(feedLikeRepository).deleteAllByFeedId(feedId);
     }
 } 

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaServiceTest.java
@@ -1,0 +1,202 @@
+package com.samsamhajo.deepground.feed.feed.service;
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.feed.feed.entity.FeedMedia;
+import com.samsamhajo.deepground.feed.feed.model.FeedMediaResponse;
+import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
+import com.samsamhajo.deepground.feed.feed.repository.FeedMediaRepository;
+import com.samsamhajo.deepground.media.MediaErrorCode;
+import com.samsamhajo.deepground.media.MediaException;
+import com.samsamhajo.deepground.media.MediaUtils;
+import com.samsamhajo.deepground.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedMediaServiceTest {
+
+    @Mock
+    private FeedMediaRepository feedMediaRepository;
+
+    @InjectMocks
+    private FeedMediaService feedMediaService;
+
+    private static final String TEST_CONTENT = "테스트 피드 내용입니다.";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "테스트유저";
+    private static final String TEST_MEDIA_URL = "test/url/image.jpg";
+    private static final String TEST_EXTENSION = "jpg";
+
+    private Member testMember;
+    private Feed testFeed;
+    private FeedMedia testFeedMedia;
+    private MockMultipartFile testImage;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        testFeed = Feed.of(TEST_CONTENT, testMember);
+        testFeedMedia = FeedMedia.of(TEST_MEDIA_URL, TEST_EXTENSION, testFeed);
+        testImage = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test image content".getBytes()
+        );
+
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(testFeed, "id", 1L);
+        ReflectionTestUtils.setField(testFeedMedia, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("피드 미디어 생성 성공")
+    void createFeedMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            mediaUtils.when(() -> MediaUtils.generateMediaUrl(any(MultipartFile.class)))
+                    .thenReturn(TEST_MEDIA_URL);
+            mediaUtils.when(() -> MediaUtils.getExtension(any(MultipartFile.class)))
+                    .thenReturn(TEST_EXTENSION);
+
+            when(feedMediaRepository.saveAll(anyList())).thenReturn(List.of(testFeedMedia));
+
+            // when
+            feedMediaService.createFeedMedia(testFeed, List.of(testImage));
+
+            // then
+            verify(feedMediaRepository).saveAll(anyList());
+        }
+    }
+
+    @Test
+    @DisplayName("피드 미디어 생성 - 이미지가 없는 경우")
+    void createFeedMediaWithEmptyImages() {
+        // when
+        feedMediaService.createFeedMedia(testFeed, List.of());
+
+        // then
+        verify(feedMediaRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("피드 미디어 조회 성공")
+    void fetchFeedMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            InputStreamResource mockResource = mock(InputStreamResource.class);
+            mediaUtils.when(() -> MediaUtils.getMedia(TEST_MEDIA_URL))
+                    .thenReturn(mockResource);
+
+            when(feedMediaRepository.getById(1L)).thenReturn(testFeedMedia);
+
+            // when
+            FeedMediaResponse response = feedMediaService.fetchFeedMedia(1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getImage()).isEqualTo(mockResource);
+            assertThat(response.getExtension()).isEqualTo(TEST_EXTENSION);
+        }
+    }
+
+    @Test
+    @DisplayName("피드 미디어 조회 실패 - 존재하지 않는 미디어")
+    void fetchFeedMediaFailWithNotFound() {
+        // given
+        when(feedMediaRepository.getById(1L))
+                .thenThrow(new MediaException(MediaErrorCode.MEDIA_NOT_FOUND, 1L));
+
+        // when & then
+        assertThatThrownBy(() -> feedMediaService.fetchFeedMedia(1L))
+                .isInstanceOf(MediaException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MediaErrorCode.MEDIA_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("피드의 모든 미디어 조회 성공")
+    void findAllByFeedSuccess() {
+        // given
+        when(feedMediaRepository.findAllByFeedId(1L)).thenReturn(List.of(testFeedMedia));
+
+        // when
+        List<FeedMedia> result = feedMediaService.findAllByFeed(testFeed);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getMediaUrl()).isEqualTo(TEST_MEDIA_URL);
+    }
+
+    @Test
+    @DisplayName("피드의 모든 미디어 삭제 성공")
+    void deleteAllByFeedIdSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            when(feedMediaRepository.findAllByFeedId(1L)).thenReturn(List.of(testFeedMedia));
+
+            // when
+            feedMediaService.deleteAllByFeedId(1L);
+
+            // then
+            mediaUtils.verify(() -> MediaUtils.deleteMedia(TEST_MEDIA_URL));
+            verify(feedMediaRepository).deleteAllByFeedId(1L);
+        }
+    }
+
+    @Test
+    @DisplayName("피드 미디어 업데이트 성공")
+    void updateFeedMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            mediaUtils.when(() -> MediaUtils.generateMediaUrl(any(MultipartFile.class)))
+                    .thenReturn(TEST_MEDIA_URL);
+            mediaUtils.when(() -> MediaUtils.getExtension(any(MultipartFile.class)))
+                    .thenReturn(TEST_EXTENSION);
+
+            when(feedMediaRepository.findAllByFeedId(1L)).thenReturn(List.of(testFeedMedia));
+            when(feedMediaRepository.saveAll(anyList())).thenReturn(List.of(testFeedMedia));
+
+            FeedUpdateRequest updateRequest = new FeedUpdateRequest(TEST_CONTENT, List.of(testImage));
+
+            // when
+            feedMediaService.updateFeedMedia(testFeed, updateRequest);
+
+            // then
+            mediaUtils.verify(() -> MediaUtils.deleteMedia(TEST_MEDIA_URL));
+            verify(feedMediaRepository).deleteAllByFeedId(1L);
+            verify(feedMediaRepository).saveAll(anyList());
+        }
+    }
+
+    @Test
+    @DisplayName("피드 미디어 ID 목록 조회 성공")
+    void findAllMediaIdsByFeedIdSuccess() {
+        // given
+        when(feedMediaRepository.findAllByFeedId(1L)).thenReturn(List.of(testFeedMedia));
+
+        // when
+        List<Long> result = feedMediaService.findAllMediaIdsByFeedId(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isEqualTo(1L);
+    }
+} 

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedServiceTest.java
@@ -1,260 +1,265 @@
 package com.samsamhajo.deepground.feed.feed.service;
 
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
-import com.samsamhajo.deepground.feed.feed.entity.FeedMedia;
 import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
 import com.samsamhajo.deepground.feed.feed.exception.FeedException;
 import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
-import com.samsamhajo.deepground.feed.feed.model.FeedListResponse;
-import com.samsamhajo.deepground.feed.feed.model.FeedResponse;
 import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
+import com.samsamhajo.deepground.feed.feed.model.FetchFeedsResponse;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
+import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentService;
+import com.samsamhajo.deepground.feed.feedshared.model.FetchSharedFeedResponse;
+import com.samsamhajo.deepground.feed.feedshared.service.SharedFeedService;
 import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.exception.MemberErrorCode;
 import com.samsamhajo.deepground.member.exception.MemberException;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.*;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.DefaultTransactionDefinition;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
 class FeedServiceTest {
 
-    @InjectMocks
+    private FeedRepository feedRepository;
+    private FeedMediaService feedMediaService;
+    private MemberRepository memberRepository;
+    private FeedCommentService feedCommentService;
+    private FeedLikeService feedLikeService;
+    private SharedFeedService sharedFeedService;
     private FeedService feedService;
 
-    @Mock
-    private FeedRepository feedRepository;
-
-    @Mock
-    private FeedMediaService feedMediaService;
-
-    @Mock
-    private MemberRepository memberRepository;
-
-    private Member member = Member.createLocalMember("choiyt3465@naver.com", "q1w2e3r4!", "yt");
-
-
-    @Mock
-    private PlatformTransactionManager transactionManager;
-
-    private TransactionStatus status;
+    private static final String TEST_CONTENT = "테스트 피드 내용입니다.";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "테스트유저";
 
     @BeforeEach
     void setUp() {
-        // 테스트 시작 전 트랜잭션 시작
-        status = transactionManager.getTransaction(new DefaultTransactionDefinition());
-    }
-
-    @AfterEach
-    void tearDown() {
-        // 테스트 종료 후 롤백 처리
-        if (status != null) {
-            transactionManager.rollback(status);
-        }
+        feedRepository = mock(FeedRepository.class);
+        feedMediaService = mock(FeedMediaService.class);
+        memberRepository = mock(MemberRepository.class);
+        feedCommentService = mock(FeedCommentService.class);
+        feedLikeService = mock(FeedLikeService.class);
+        sharedFeedService = mock(SharedFeedService.class);
+        feedService = new FeedService(
+            feedRepository,
+            feedMediaService,
+            memberRepository,
+            feedCommentService,
+            feedLikeService, sharedFeedService
+        );
     }
 
     @Test
-    @DisplayName("피드 생성 성공 테스트")
-    void createFeed_Success() {
+    @DisplayName("피드 생성 성공")
+    void createFeedSuccess() {
         // given
-        String content = "테스트 피드 내용";
-        Long memberId = 1L;
-        
-        Feed feed = Feed.of(content, member);
-        
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(feedRepository.save(any(Feed.class))).willReturn(feed);
-        
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        FeedCreateRequest request = new FeedCreateRequest(TEST_CONTENT, List.of());
+        Feed expectedFeed = Feed.of(TEST_CONTENT, testMember);
+
+        when(memberRepository.findById(testMember.getId())).thenReturn(Optional.of(testMember));
+        when(feedRepository.save(any(Feed.class))).thenReturn(expectedFeed);
+
         // when
-        Feed createdFeed = feedService.createFeed(new FeedCreateRequest(content, null), memberId);
-        
+        Feed createdFeed = feedService.createFeed(request, testMember.getId());
+
         // then
         assertThat(createdFeed).isNotNull();
-        assertThat(createdFeed.getContent()).isEqualTo(content);
-        assertThat(createdFeed.getMember()).isEqualTo(member);
+        assertThat(createdFeed.getContent()).isEqualTo(TEST_CONTENT);
+        assertThat(createdFeed.getMember().getId()).isEqualTo(testMember.getId());
+        
+        verify(feedMediaService).createFeedMedia(any(Feed.class), anyList());
     }
 
     @Test
-    @DisplayName("피드 생성 실패 테스트 - 존재하지 않는 회원")
-    void createFeed_Fail_MemberNotFound() {
+    @DisplayName("피드 생성 실패 - 내용이 비어있는 경우")
+    void createFeedFailWithEmptyContent() {
         // given
-        String content = "테스트 피드 내용";
-        Long nonExistentMemberId = 999L;
-        
-        given(memberRepository.findById(nonExistentMemberId)).willReturn(Optional.empty());
-        
+        FeedCreateRequest request = new FeedCreateRequest("", List.of());
+
         // when & then
-        assertThatThrownBy(() -> feedService.createFeed(new FeedCreateRequest(content, null), nonExistentMemberId))
-                .isInstanceOf(MemberException.class);
-    }
-
-    @Test
-    @DisplayName("피드 목록 조회 테스트")
-    void getFeeds_Success() {
-        // given
-        int page = 0;
-        int size = 20;
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        
-        Feed feed1 = Feed.of("첫 번째 피드", member);
-        Feed feed2 = Feed.of("두 번째 피드", member);
-        
-        List<Feed> feeds = List.of(feed1, feed2);
-        Page<Feed> feedPage = new PageImpl<>(feeds, pageable, feeds.size());
-        
-        List<FeedMedia> feed1Medias = List.of(
-                FeedMedia.of("url1", "jpg", feed1),
-                FeedMedia.of("url2", "jpg", feed1)
-        );
-        
-        List<FeedMedia> feed2Medias = List.of(
-                FeedMedia.of("url3", "jpg", feed2)
-        );
-        
-        // Mock 설정
-        when(feedRepository.findAll(pageable)).thenReturn(feedPage);
-        when(feedMediaService.findAllByFeed(feed1)).thenReturn(feed1Medias);
-        when(feedMediaService.findAllByFeed(feed2)).thenReturn(feed2Medias);
-        
-        // when
-        FeedListResponse result = feedService.getFeeds(pageable);
-        
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getFeeds()).hasSize(2);
-        assertThat(result.getCurrentPage()).isEqualTo(page);
-        assertThat(result.getTotalPages()).isEqualTo(1);
-        
-        // 첫 번째 피드 검증
-        FeedResponse firstFeed = result.getFeeds().get(0);
-        assertThat(firstFeed.getContent()).isEqualTo("첫 번째 피드");
-        assertThat(firstFeed.getMemberName()).isEqualTo("yt");
-        assertThat(firstFeed.getImageIds()).hasSize(2);
-        
-        // 두 번째 피드 검증
-        FeedResponse secondFeed = result.getFeeds().get(1);
-        assertThat(secondFeed.getContent()).isEqualTo("두 번째 피드");
-        assertThat(secondFeed.getMemberName()).isEqualTo("yt");
-        assertThat(secondFeed.getImageIds()).hasSize(1);
-    }
-    
-    @Test
-    @DisplayName("피드 수정 성공 테스트")
-    void updateFeed_Success() {
-        // given
-        Long feedId = 1L;
-        Long memberId = 1L;
-        String originalContent = "원본 피드 내용";
-        String updatedContent = "수정된 피드 내용";
-        
-        Feed originalFeed = Feed.of(originalContent, member);
-        
-        MockMultipartFile mockImage = new MockMultipartFile(
-                "image", 
-                "test.jpg", 
-                "image/jpeg", 
-                "테스트 이미지 데이터".getBytes()
-        );
-        
-        List<MultipartFile> updatedImages = List.of(mockImage);
-        FeedUpdateRequest updateRequest = new FeedUpdateRequest(updatedContent, updatedImages);
-
-        when(feedRepository.getById(feedId)).thenReturn(originalFeed);
-        
-        // when
-        Feed updatedFeed = feedService.updateFeed(feedId, updateRequest, memberId);
-        
-        // then
-        assertThat(updatedFeed).isNotNull();
-        assertThat(updatedFeed.getContent()).isEqualTo(updatedContent);
-        
-        // feedMediaService의 메서드가 호출되었는지 검증
-        verify(feedMediaService, times(1)).updateFeedMedia(eq(originalFeed), eq(updateRequest));
-    }
-    
-    @Test
-    @DisplayName("피드 수정 실패 테스트 - 빈 내용")
-    void updateFeed_Fail_EmptyContent() {
-        // given
-        Long feedId = 1L;
-        Long memberId = 1L;
-        String emptyContent = "";
-        
-        MockMultipartFile mockImage = new MockMultipartFile(
-                "image", 
-                "test.jpg", 
-                "image/jpeg", 
-                "테스트 이미지 데이터".getBytes()
-        );
-        
-        List<MultipartFile> updatedImages = List.of(mockImage);
-        FeedUpdateRequest updateRequest = new FeedUpdateRequest(emptyContent, updatedImages);
-        
-        // when & then
-        assertThatThrownBy(() -> feedService.updateFeed(feedId, updateRequest, memberId))
+        assertThatThrownBy(() -> feedService.createFeed(request, 1L))
                 .isInstanceOf(FeedException.class)
                 .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.INVALID_FEED_CONTENT);
-        
-        // feedRepository.getById가 호출되지 않았는지 검증
-        verify(feedRepository, times(0)).getById(anyLong());
     }
-    
+
     @Test
-    @DisplayName("피드 수정 실패 테스트 - 존재하지 않는 피드")
-    void updateFeed_Fail_FeedNotFound() {
+    @DisplayName("피드 생성 실패 - 존재하지 않는 회원")
+    void createFeedFailWithInvalidMember() {
         // given
-        Long nonExistentFeedId = 999L;
-        Long memberId = 1L;
-        String updatedContent = "수정된 피드 내용";
-        
-        FeedUpdateRequest updateRequest = new FeedUpdateRequest(updatedContent, null);
-        
-        when(feedRepository.getById(nonExistentFeedId))
-                .thenThrow(new FeedException(FeedErrorCode.FEED_NOT_FOUND));
-        
+        FeedCreateRequest request = new FeedCreateRequest(TEST_CONTENT, List.of());
+        Long invalidMemberId = 999L;
+
+        when(memberRepository.findById(invalidMemberId)).thenReturn(Optional.empty());
+
         // when & then
-        assertThatThrownBy(() -> feedService.updateFeed(nonExistentFeedId, updateRequest, memberId))
-                .isInstanceOf(FeedException.class)
-                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.FEED_NOT_FOUND);
+        assertThatThrownBy(() -> feedService.createFeed(request, invalidMemberId))
+                .isInstanceOf(MemberException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
     }
-    
+
     @Test
-    @DisplayName("피드 삭제 성공 테스트")
-    void deleteFeed_Success() {
+    @DisplayName("피드 수정 성공")
+    void updateFeedSuccess() {
         // given
-        Long feedId = 1L;
-        Long memberId = 1L;
-        
-        Feed feed = Feed.of("테스트 피드 내용", member);
-        
-        given(feedRepository.getById(feedId)).willReturn(feed);
-        
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed existingFeed = Feed.of(TEST_CONTENT, testMember);
+        String updatedContent = "수정된 피드 내용입니다.";
+        FeedUpdateRequest updateRequest = new FeedUpdateRequest(updatedContent, List.of());
+        when(feedRepository.getById(existingFeed.getId())).thenReturn(existingFeed);
+
         // when
-        feedService.deleteFeed(feedId, memberId);
-        
+        Feed updatedFeed = feedService.updateFeed(existingFeed.getId(), updateRequest, testMember.getId());
+
         // then
-        verify(feedRepository, times(1)).getById(feedId);
-        verify(feedMediaService, times(1)).deleteAllByFeedId(feedId);
-        assertThat(feed.isDeleted()).isTrue();
+        assertThat(updatedFeed.getContent()).isEqualTo(updatedContent);
+        verify(feedMediaService).updateFeedMedia(any(Feed.class), any(FeedUpdateRequest.class));
     }
-}
+
+    @Test
+    @DisplayName("피드 수정 실패 - 내용이 비어있는 경우")
+    void updateFeedFailWithEmptyContent() {
+        // given
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed existingFeed = Feed.of(TEST_CONTENT, testMember);
+        FeedUpdateRequest updateRequest = new FeedUpdateRequest("", List.of());
+
+        when(feedRepository.findById(existingFeed.getId())).thenReturn(Optional.of(existingFeed));
+
+        // when & then
+        assertThatThrownBy(() -> feedService.updateFeed(existingFeed.getId(), updateRequest, testMember.getId()))
+                .isInstanceOf(FeedException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FeedErrorCode.INVALID_FEED_CONTENT);
+    }
+
+    @Test
+    @DisplayName("피드 목록 조회 성공")
+    void getFeedsSuccess() {
+        // given
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed feed1 = Feed.of("피드1", testMember);
+        Feed feed2 = Feed.of("피드2", testMember);
+
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(feed1, "id", 1L);
+        ReflectionTestUtils.setField(feed2, "id", 2L);
+        ReflectionTestUtils.setField(feed1, "createdAt", java.time.LocalDateTime.now());
+        ReflectionTestUtils.setField(feed2, "createdAt", java.time.LocalDateTime.now());
+
+        Page<Feed> feedPage = new PageImpl<>(List.of(feed2, feed1));
+
+        when(feedRepository.findAll(any(Pageable.class))).thenReturn(feedPage);
+        when(feedMediaService.findAllMediaIdsByFeedId(anyLong())).thenReturn(List.of());
+        when(feedCommentService.countFeedCommentsByFeedId(anyLong())).thenReturn(0);
+        when(feedLikeService.countFeedLikeByFeedId(anyLong())).thenReturn(0);
+        when(feedLikeService.isLiked(anyLong(), anyLong())).thenReturn(false);
+        when(sharedFeedService.getSharedFeedResponse(anyLong())).thenReturn(null);
+        when(sharedFeedService.countSharedFeedByOriginFeedId(anyLong())).thenReturn(0);
+
+        // when
+        FetchFeedsResponse result = feedService.getFeeds(PageRequest.of(0, 10), testMember.getId());
+
+        // then
+        assertThat(result.getFeeds()).hasSize(2);
+        assertThat(result.getFeeds().get(0).getContent()).isEqualTo("피드2");
+        assertThat(result.getFeeds().get(1).getContent()).isEqualTo("피드1");
+        assertThat(result.getFeeds().get(0).getMemberId()).isEqualTo(1L);
+        assertThat(result.getFeeds().get(1).getMemberId()).isEqualTo(1L);
+        assertThat(result.getFeeds().get(0).getMemberName()).isEqualTo(TEST_NICKNAME);
+        assertThat(result.getFeeds().get(1).getMemberName()).isEqualTo(TEST_NICKNAME);
+        assertThat(result.getFeeds().get(0).getShareCount()).isEqualTo(0);
+        assertThat(result.getFeeds().get(1).getShareCount()).isEqualTo(0);
+        assertThat(result.getFeeds().get(0).isShared()).isFalse();
+        assertThat(result.getFeeds().get(1).isShared()).isFalse();
+        assertThat(result.getFeeds().get(0).getSharedFeed()).isNull();
+        assertThat(result.getFeeds().get(1).getSharedFeed()).isNull();
+    }
+
+    @Test
+    @DisplayName("피드 목록 조회 성공 - 공유된 피드 포함")
+    void getFeedsSuccessWithSharedFeed() {
+        // given
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed feed1 = Feed.of("피드1", testMember);
+        Feed feed2 = Feed.of("피드2", testMember);
+
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(feed1, "id", 1L);
+        ReflectionTestUtils.setField(feed2, "id", 2L);
+        ReflectionTestUtils.setField(feed1, "createdAt", java.time.LocalDateTime.now());
+        ReflectionTestUtils.setField(feed2, "createdAt", java.time.LocalDateTime.now());
+
+        Page<Feed> feedPage = new PageImpl<>(List.of(feed2, feed1));
+
+        FetchSharedFeedResponse sharedFeedResponse = FetchSharedFeedResponse.builder()
+                .feedId(3L)
+                .memberId(2L)
+                .memberName("원본작성자")
+                .content("원본 피드 내용")
+                .createdAt(java.time.LocalDate.now())
+                .mediaIds(List.of(1L, 2L))
+                .build();
+
+        when(feedRepository.findAll(any(Pageable.class))).thenReturn(feedPage);
+        when(feedMediaService.findAllMediaIdsByFeedId(anyLong())).thenReturn(List.of());
+        when(feedCommentService.countFeedCommentsByFeedId(anyLong())).thenReturn(0);
+        when(feedLikeService.countFeedLikeByFeedId(anyLong())).thenReturn(0);
+        when(feedLikeService.isLiked(anyLong(), anyLong())).thenReturn(false);
+        when(sharedFeedService.getSharedFeedResponse(1L)).thenReturn(sharedFeedResponse);
+        when(sharedFeedService.getSharedFeedResponse(2L)).thenReturn(null);
+        when(sharedFeedService.countSharedFeedByOriginFeedId(1L)).thenReturn(5);
+        when(sharedFeedService.countSharedFeedByOriginFeedId(2L)).thenReturn(0);
+
+        // when
+        FetchFeedsResponse result = feedService.getFeeds(PageRequest.of(0, 10), testMember.getId());
+
+        // then
+        assertThat(result.getFeeds()).hasSize(2);
+        assertThat(result.getFeeds().get(0).getContent()).isEqualTo("피드2");
+        assertThat(result.getFeeds().get(1).getContent()).isEqualTo("피드1");
+        assertThat(result.getFeeds().get(0).getShareCount()).isEqualTo(0);
+        assertThat(result.getFeeds().get(1).getShareCount()).isEqualTo(5);
+        assertThat(result.getFeeds().get(0).isShared()).isFalse();
+        assertThat(result.getFeeds().get(1).isShared()).isTrue();
+        assertThat(result.getFeeds().get(0).getSharedFeed()).isNull();
+        assertThat(result.getFeeds().get(1).getSharedFeed()).isNotNull();
+        assertThat(result.getFeeds().get(1).getSharedFeed().getFeedId()).isEqualTo(3L);
+        assertThat(result.getFeeds().get(1).getSharedFeed().getMemberId()).isEqualTo(2L);
+        assertThat(result.getFeeds().get(1).getSharedFeed().getMemberName()).isEqualTo("원본작성자");
+        assertThat(result.getFeeds().get(1).getSharedFeed().getContent()).isEqualTo("원본 피드 내용");
+        assertThat(result.getFeeds().get(1).getSharedFeed().getMediaIds()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("피드 삭제 성공")
+    void deleteFeedSuccess() {
+        // given
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed existingFeed = Feed.of(TEST_CONTENT, testMember);
+
+        when(feedRepository.getById(existingFeed.getId())).thenReturn(existingFeed);
+
+        // when
+        feedService.deleteFeed(existingFeed.getId());
+
+        // then
+        verify(feedCommentService).deleteFeedCommentByFeed(existingFeed.getId());
+        verify(feedLikeService).deleteAllByFeedId(existingFeed.getId());
+        verify(feedMediaService).deleteAllByFeedId(existingFeed.getId());
+        verify(feedRepository).deleteById(existingFeed.getId());
+    }
+} 

--- a/src/test/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentMediaServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentMediaServiceTest.java
@@ -1,0 +1,194 @@
+package com.samsamhajo.deepground.feed.feedcomment.service;
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.feed.feedcomment.entity.FeedComment;
+import com.samsamhajo.deepground.feed.feedcomment.entity.FeedCommentMedia;
+import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentMediaResponse;
+import com.samsamhajo.deepground.feed.feedcomment.repository.FeedCommentMediaRepository;
+import com.samsamhajo.deepground.media.MediaErrorCode;
+import com.samsamhajo.deepground.media.MediaException;
+import com.samsamhajo.deepground.media.MediaUtils;
+import com.samsamhajo.deepground.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedCommentMediaServiceTest {
+
+    @Mock
+    private FeedCommentMediaRepository feedCommentMediaRepository;
+
+    @InjectMocks
+    private FeedCommentMediaService feedCommentMediaService;
+
+    private static final String TEST_CONTENT = "테스트 댓글 내용입니다.";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "테스트유저";
+    private static final String TEST_MEDIA_URL = "test.jpg";
+    private static final String TEST_EXTENSION = "jpg";
+
+    private Member testMember;
+    private Feed testFeed;
+    private FeedComment testFeedComment;
+    private FeedCommentMedia testFeedCommentMedia;
+    private MockMultipartFile testImage;
+    private InputStreamResource mockResource;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        testFeed = Feed.of(TEST_CONTENT, testMember);
+        testFeedComment = FeedComment.of(TEST_CONTENT, testFeed, testMember);
+        testFeedCommentMedia = FeedCommentMedia.of(TEST_MEDIA_URL, TEST_EXTENSION, testFeedComment);
+        testImage = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test image content".getBytes()
+        );
+        mockResource = new InputStreamResource(testImage.getInputStream());
+
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(testFeed, "id", 1L);
+        ReflectionTestUtils.setField(testFeedComment, "id", 1L);
+        ReflectionTestUtils.setField(testFeedCommentMedia, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("피드 댓글 미디어 생성 성공")
+    void createFeedCommentMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            mediaUtils.when(() -> MediaUtils.generateMediaUrl(any(MultipartFile.class)))
+                    .thenReturn(TEST_MEDIA_URL);
+            mediaUtils.when(() -> MediaUtils.getExtension(any(MultipartFile.class)))
+                    .thenReturn(TEST_EXTENSION);
+
+            when(feedCommentMediaRepository.saveAll(anyList())).thenReturn(List.of(testFeedCommentMedia));
+
+            // when
+            feedCommentMediaService.createFeedCommentMedia(testFeedComment, List.of(testImage));
+
+            // then
+            verify(feedCommentMediaRepository).saveAll(anyList());
+        }
+    }
+
+    @Test
+    @DisplayName("피드 댓글 미디어 생성 성공 - 이미지가 없는 경우")
+    void createFeedCommentMediaSuccessWithNoImages() {
+        // when
+        feedCommentMediaService.createFeedCommentMedia(testFeedComment, List.of());
+
+        // then
+        verify(feedCommentMediaRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("피드 댓글 미디어 조회 성공")
+    void fetchFeedCommentMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            mediaUtils.when(() -> MediaUtils.getMedia(anyString())).thenReturn(mockResource);
+
+            when(feedCommentMediaRepository.findById(1L)).thenReturn(java.util.Optional.of(testFeedCommentMedia));
+
+            // when
+            FeedCommentMediaResponse response = feedCommentMediaService.fetchFeedCommentMedia(1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getImage()).isEqualTo(mockResource);
+            assertThat(response.getExtension()).isEqualTo(TEST_EXTENSION);
+        }
+    }
+
+    @Test
+    @DisplayName("피드 댓글 미디어 조회 실패 - 미디어가 존재하지 않는 경우")
+    void fetchFeedCommentMediaFailWithNotFound() {
+        // given
+        when(feedCommentMediaRepository.findById(1L)).thenReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedCommentMediaService.fetchFeedCommentMedia(1L))
+                .isInstanceOf(MediaException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MediaErrorCode.MEDIA_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("피드 댓글 미디어 삭제 성공")
+    void deleteAllByFeedCommentIdSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            when(feedCommentMediaRepository.findAllByFeedCommentId(1L))
+                    .thenReturn(List.of(testFeedCommentMedia));
+
+            // when
+            feedCommentMediaService.deleteAllByFeedCommentId(1L);
+
+            // then
+            mediaUtils.verify(() -> MediaUtils.deleteMedia(anyString()));
+            verify(feedCommentMediaRepository).deleteAllByFeedCommentId(1L);
+        }
+    }
+
+    @Test
+    @DisplayName("피드 댓글 미디어 ID 목록 조회 성공")
+    void getFeedCommentMediaIdsSuccess() {
+        // given
+        when(feedCommentMediaRepository.findAllByFeedCommentId(1L))
+                .thenReturn(List.of(testFeedCommentMedia));
+
+        // when
+        List<Long> mediaIds = feedCommentMediaService.getFeedCommentMediaIds(1L);
+
+        // then
+        assertThat(mediaIds).hasSize(1);
+        assertThat(mediaIds.get(0)).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("피드 댓글 미디어 업데이트 성공")
+    void updateFeedCommentMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            mediaUtils.when(() -> MediaUtils.generateMediaUrl(any(MultipartFile.class)))
+                    .thenReturn(TEST_MEDIA_URL);
+            mediaUtils.when(() -> MediaUtils.getExtension(any(MultipartFile.class)))
+                    .thenReturn(TEST_EXTENSION);
+
+            when(feedCommentMediaRepository.findAllByFeedCommentId(1L))
+                    .thenReturn(List.of(testFeedCommentMedia));
+            when(feedCommentMediaRepository.saveAll(anyList()))
+                    .thenReturn(List.of(testFeedCommentMedia));
+
+            // when
+            feedCommentMediaService.updateFeedCommentMedia(testFeedComment, List.of(testImage));
+
+            // then
+            mediaUtils.verify(() -> MediaUtils.deleteMedia(anyString()));
+            verify(feedCommentMediaRepository).deleteAllByFeedCommentId(1L);
+            verify(feedCommentMediaRepository).saveAll(anyList());
+        }
+    }
+} 

--- a/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyLikeServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyLikeServiceTest.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.feed.feedreply.service;
 
+import com.samsamhajo.deepground.feed.feedcomment.entity.FeedComment;
 import com.samsamhajo.deepground.feed.feedreply.entity.FeedReply;
 import com.samsamhajo.deepground.feed.feedreply.entity.FeedReplyLike;
 import com.samsamhajo.deepground.feed.feedreply.exception.FeedReplyErrorCode;
@@ -12,129 +13,158 @@ import com.samsamhajo.deepground.member.exception.MemberException;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class FeedReplyLikeServiceTest {
 
     @Mock
     private FeedReplyRepository feedReplyRepository;
-    @Mock
-    private MemberRepository memberRepository;
+
     @Mock
     private FeedReplyLikeRepository feedReplyLikeRepository;
 
     @InjectMocks
     private FeedReplyLikeService feedReplyLikeService;
 
+    @Mock
+    private MemberRepository memberRepository;
+
+    private static final String TEST_CONTENT = "테스트 답글 내용입니다.";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "테스트유저";
+
+    private Member testMember;
+    private FeedComment testFeedComment;
+    private FeedReply testFeedReply;
+    private FeedReplyLike testFeedReplyLike;
+
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
+        testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        testFeedComment = FeedComment.of(TEST_CONTENT, null, testMember);
+        testFeedReply = FeedReply.of(TEST_CONTENT, testFeedComment, testMember);
+        testFeedReplyLike = FeedReplyLike.of(testFeedReply, testMember);
+
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(testFeedComment, "id", 1L);
+        ReflectionTestUtils.setField(testFeedReply, "id", 1L);
+        ReflectionTestUtils.setField(testFeedReplyLike, "id", 1L);
     }
 
-    @Nested
-    @DisplayName("성공 케이스")
-    class SuccessCases {
-        @Test
-        @DisplayName("답글 좋아요 성공")
-        void feedReplyLikeIncrease_success() {
-            Long feedReplyId = 1L;
-            Long memberId = 2L;
-            FeedReply feedReply = mock(FeedReply.class);
-            Member member = mock(Member.class);
+    @Test
+    @DisplayName("피드 답글 좋아요 증가 성공")
+    void feedReplyLikeIncreaseSuccess() {
+        // given
+        when(feedReplyRepository.getById(1L)).thenReturn(testFeedReply);
+        when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(1L, 1L)).thenReturn(false);
+        when(feedReplyLikeRepository.save(any(FeedReplyLike.class))).thenReturn(testFeedReplyLike);
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
 
-            when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(feedReplyId, memberId)).thenReturn(false);
-            when(feedReplyRepository.getById(feedReplyId)).thenReturn(feedReply);
-            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-            when(feedReplyLikeRepository.save(any(FeedReplyLike.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        // when
+        feedReplyLikeService.feedReplyLikeIncrease(1L, 1L);
 
-            feedReplyLikeService.feedReplyLikeIncrease(feedReplyId, memberId);
-
-            verify(feedReplyLikeRepository, times(1)).save(any(FeedReplyLike.class));
-        }
-
-        @Test
-        @DisplayName("답글 좋아요 취소 성공")
-        void feedReplyLikeDecrease_success() {
-            Long feedReplyId = 1L;
-            Long memberId = 2L;
-            FeedReplyLike feedReplyLike = mock(FeedReplyLike.class);
-
-            when(feedReplyLikeRepository.countByFeedReplyId(feedReplyId)).thenReturn(1);
-            when(feedReplyLikeRepository.getByFeedReplyIdAndMemberId(feedReplyId, memberId)).thenReturn(feedReplyLike);
-
-            feedReplyLikeService.feedReplyLikeDecrease(feedReplyId, memberId);
-
-            verify(feedReplyLikeRepository, times(1)).delete(feedReplyLike);
-        }
+        // then
+        verify(feedReplyLikeRepository).save(any(FeedReplyLike.class));
     }
 
-    @Nested
-    @DisplayName("실패 케이스")
-    class FailureCases {
-        @Test
-        @DisplayName("이미 좋아요를 누른 답글에 또 좋아요를 누를 때 예외")
-        void feedReplyLikeIncrease_fail_alreadyExists() {
-            Long feedReplyId = 1L;
-            Long memberId = 2L;
+    @Test
+    @DisplayName("피드 답글 좋아요 증가 실패 - 이미 좋아요를 누른 경우")
+    void feedReplyLikeIncreaseFailWithAlreadyLiked() {
+        // given
+        when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(1L, 1L)).thenReturn(true);
 
-            when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(feedReplyId, memberId)).thenReturn(true);
+        // when & then
+        assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeIncrease(1L, 1L))
+                .isInstanceOf(FeedReplyException.class)
+                .hasMessage(FeedReplyErrorCode.FEED_REPLY_LIKE_ALREADY_EXISTS.getMessage());
+    }
 
-            assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeIncrease(feedReplyId, memberId))
-                    .isInstanceOf(FeedReplyException.class)
-                    .hasMessage(FeedReplyErrorCode.FEED_REPLY_LIKE_ALREADY_EXISTS.getMessage());
-        }
+    @Test
+    @DisplayName("피드 답글 좋아요 증가 실패 - 존재하지 않는 회원")
+    void feedReplyLikeIncreaseFailWithInvalidMember() {
+        // given
+        when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(1L, 1L))
+                .thenThrow(new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
-        @Test
-        @DisplayName("멤버가 존재하지 않을 때 예외")
-        void feedReplyLikeIncrease_fail_memberNotFound() {
-            Long feedReplyId = 1L;
-            Long memberId = 2L;
+        // when & then
+        assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeIncrease(1L, 1L))
+                .isInstanceOf(MemberException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
+    }
 
-            when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(feedReplyId, memberId)).thenReturn(false);
-            when(feedReplyRepository.getById(feedReplyId)).thenReturn(mock(FeedReply.class));
-            when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+    @Test
+    @DisplayName("피드 답글 좋아요 감소 성공")
+    void feedReplyLikeDecreaseSuccess() {
+        // given
+        when(feedReplyLikeRepository.getByFeedReplyIdAndMemberId(1L, 1L))
+                .thenReturn(testFeedReplyLike);
+        when(feedReplyLikeRepository.countByFeedReplyId(1L)).thenReturn(1);
 
-            assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeIncrease(feedReplyId, memberId))
-                    .isInstanceOf(MemberException.class)
-                    .hasMessage(MemberErrorCode.INVALID_MEMBER_ID.getMessage());
-        }
+        // when
+        feedReplyLikeService.feedReplyLikeDecrease(1L, 1L);
 
-        @Test
-        @DisplayName("좋아요가 0 이하일 때 취소 시도 예외")
-        void feedReplyLikeDecrease_fail_likeMinusNotAllowed() {
-            Long feedReplyId = 1L;
-            Long memberId = 2L;
+        // then
+        verify(feedReplyLikeRepository).delete(testFeedReplyLike);
+    }
 
-            when(feedReplyLikeRepository.countByFeedReplyId(feedReplyId)).thenReturn(0);
+    @Test
+    @DisplayName("피드 답글 좋아요 감소 실패 - 좋아요가 없는 경우")
+    void feedReplyLikeDecreaseFailWithNoLikes() {
+        // when & then
+        assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeDecrease(1L, 1L))
+                .isInstanceOf(FeedReplyException.class)
+                .hasMessage(FeedReplyErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED.getMessage());
+    }
 
-            assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeDecrease(feedReplyId, memberId))
-                    .isInstanceOf(FeedReplyException.class)
-                    .hasMessage(FeedReplyErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED.getMessage());
-        }
+    @Test
+    @DisplayName("피드 답글 좋아요 수 조회 성공")
+    void countFeedReplyLikeByFeedReplyIdSuccess() {
+        // given
+        when(feedReplyLikeRepository.countByFeedReplyId(1L)).thenReturn(5);
 
-        @Test
-        @DisplayName("좋아요 취소 시 해당 좋아요가 없을 때 예외")
-        void feedReplyLikeDecrease_fail_likeNotFound() {
-            Long feedReplyId = 1L;
-            Long memberId = 2L;
+        // when
+        int likeCount = feedReplyLikeService.countFeedReplyLikeByFeedReplyId(1L);
 
-            when(feedReplyLikeRepository.countByFeedReplyId(feedReplyId)).thenReturn(1);
-            when(feedReplyLikeRepository.getByFeedReplyIdAndMemberId(feedReplyId, memberId))
-                    .thenThrow(new FeedReplyException(FeedReplyErrorCode.FEED_REPLY_LIKE_NOT_FOUND));
+        // then
+        assertThat(likeCount).isEqualTo(5L);
+    }
 
-            assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeDecrease(feedReplyId, memberId))
-                    .isInstanceOf(FeedReplyException.class)
-                    .hasMessage(FeedReplyErrorCode.FEED_REPLY_LIKE_NOT_FOUND.getMessage());
-        }
+    @Test
+    @DisplayName("피드 답글의 모든 좋아요 삭제 성공")
+    void deleteAllByFeedReplyIdSuccess() {
+        // given & when
+        feedReplyLikeService.deleteAllByFeedReplyId(1L);
+
+        // then
+        verify(feedReplyLikeRepository).deleteAllByFeedReplyId(1L);
+    }
+
+    @Test
+    @DisplayName("피드 답글 좋아요 여부 확인 성공")
+    void isLikedSuccess() {
+        // given
+        when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(1L, 1L)).thenReturn(true);
+
+        // when
+        boolean isLiked = feedReplyLikeService.isLiked(1L, 1L);
+
+        // then
+        assertThat(isLiked).isTrue();
     }
 } 

--- a/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyMediaServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyMediaServiceTest.java
@@ -1,0 +1,194 @@
+package com.samsamhajo.deepground.feed.feedreply.service;
+
+import com.samsamhajo.deepground.feed.feedcomment.entity.FeedComment;
+import com.samsamhajo.deepground.feed.feedreply.entity.FeedReply;
+import com.samsamhajo.deepground.feed.feedreply.entity.FeedReplyMedia;
+import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyMediaResponse;
+import com.samsamhajo.deepground.feed.feedreply.repository.FeedReplyMediaRepository;
+import com.samsamhajo.deepground.media.MediaErrorCode;
+import com.samsamhajo.deepground.media.MediaException;
+import com.samsamhajo.deepground.media.MediaUtils;
+import com.samsamhajo.deepground.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedReplyMediaServiceTest {
+
+    @Mock
+    private FeedReplyMediaRepository feedReplyMediaRepository;
+
+    @InjectMocks
+    private FeedReplyMediaService feedReplyMediaService;
+
+    private static final String TEST_CONTENT = "테스트 답글 내용입니다.";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "테스트유저";
+    private static final String TEST_MEDIA_URL = "test.jpg";
+    private static final String TEST_EXTENSION = "jpg";
+
+    private Member testMember;
+    private FeedComment testFeedComment;
+    private FeedReply testFeedReply;
+    private FeedReplyMedia testFeedReplyMedia;
+    private MockMultipartFile testImage;
+    private InputStreamResource mockResource;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        testFeedComment = FeedComment.of(TEST_CONTENT, null, testMember);
+        testFeedReply = FeedReply.of(TEST_CONTENT, testFeedComment, testMember);
+        testFeedReplyMedia = FeedReplyMedia.of(TEST_MEDIA_URL, TEST_EXTENSION, testFeedReply);
+        testImage = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test image content".getBytes()
+        );
+        mockResource = new InputStreamResource(testImage.getInputStream());
+
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(testFeedComment, "id", 1L);
+        ReflectionTestUtils.setField(testFeedReply, "id", 1L);
+        ReflectionTestUtils.setField(testFeedReplyMedia, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("피드 답글 미디어 생성 성공")
+    void createFeedReplyMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            mediaUtils.when(() -> MediaUtils.generateMediaUrl(any(MultipartFile.class)))
+                    .thenReturn(TEST_MEDIA_URL);
+            mediaUtils.when(() -> MediaUtils.getExtension(any(MultipartFile.class)))
+                    .thenReturn(TEST_EXTENSION);
+
+            when(feedReplyMediaRepository.saveAll(anyList())).thenReturn(List.of(testFeedReplyMedia));
+
+            // when
+            feedReplyMediaService.createFeedReplyMedia(testFeedReply, List.of(testImage));
+
+            // then
+            verify(feedReplyMediaRepository).saveAll(anyList());
+        }
+    }
+
+    @Test
+    @DisplayName("피드 답글 미디어 생성 성공 - 이미지가 없는 경우")
+    void createFeedReplyMediaSuccessWithNoImages() {
+        // when
+        feedReplyMediaService.createFeedReplyMedia(testFeedReply, List.of());
+
+        // then
+        verify(feedReplyMediaRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("피드 답글 미디어 조회 성공")
+    void fetchFeedReplyMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            mediaUtils.when(() -> MediaUtils.getMedia(anyString())).thenReturn(mockResource);
+
+            when(feedReplyMediaRepository.findById(1L)).thenReturn(java.util.Optional.of(testFeedReplyMedia));
+
+            // when
+            FeedReplyMediaResponse response = feedReplyMediaService.fetchFeedReplyMedia(1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getImage()).isEqualTo(mockResource);
+            assertThat(response.getExtension()).isEqualTo(TEST_EXTENSION);
+        }
+    }
+
+    @Test
+    @DisplayName("피드 답글 미디어 조회 실패 - 미디어가 존재하지 않는 경우")
+    void fetchFeedReplyMediaFailWithNotFound() {
+        // given
+        when(feedReplyMediaRepository.findById(1L)).thenReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedReplyMediaService.fetchFeedReplyMedia(1L))
+                .isInstanceOf(MediaException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MediaErrorCode.MEDIA_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("피드 답글 미디어 삭제 성공")
+    void deleteAllByFeedReplyIdSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            when(feedReplyMediaRepository.findAllByFeedReplyId(1L))
+                    .thenReturn(List.of(testFeedReplyMedia));
+
+            // when
+            feedReplyMediaService.deleteAllByFeedReplyId(1L);
+
+            // then
+            mediaUtils.verify(() -> MediaUtils.deleteMedia(anyString()));
+            verify(feedReplyMediaRepository).deleteAllByFeedReplyId(1L);
+        }
+    }
+
+    @Test
+    @DisplayName("피드 답글 미디어 ID 목록 조회 성공")
+    void getFeedReplyMediaIdsSuccess() {
+        // given
+        when(feedReplyMediaRepository.findAllByFeedReplyId(1L))
+                .thenReturn(List.of(testFeedReplyMedia));
+
+        // when
+        List<Long> mediaIds = feedReplyMediaService.getFeedReplyMediaIds(1L);
+
+        // then
+        assertThat(mediaIds).hasSize(1);
+        assertThat(mediaIds.get(0)).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("피드 답글 미디어 업데이트 성공")
+    void updateFeedReplyMediaSuccess() {
+        // given
+        try (MockedStatic<MediaUtils> mediaUtils = mockStatic(MediaUtils.class)) {
+            mediaUtils.when(() -> MediaUtils.generateMediaUrl(any(MultipartFile.class)))
+                    .thenReturn(TEST_MEDIA_URL);
+            mediaUtils.when(() -> MediaUtils.getExtension(any(MultipartFile.class)))
+                    .thenReturn(TEST_EXTENSION);
+
+            when(feedReplyMediaRepository.findAllByFeedReplyId(1L))
+                    .thenReturn(List.of(testFeedReplyMedia));
+            when(feedReplyMediaRepository.saveAll(anyList()))
+                    .thenReturn(List.of(testFeedReplyMedia));
+
+            // when
+            feedReplyMediaService.updateFeedReplyMedia(testFeedReply, List.of(testImage));
+
+            // then
+            mediaUtils.verify(() -> MediaUtils.deleteMedia(anyString()));
+            verify(feedReplyMediaRepository).deleteAllByFeedReplyId(1L);
+            verify(feedReplyMediaRepository).saveAll(anyList());
+        }
+    }
+} 

--- a/src/test/java/com/samsamhajo/deepground/feed/feedshared/service/SharedFeedServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedshared/service/SharedFeedServiceTest.java
@@ -1,0 +1,201 @@
+package com.samsamhajo.deepground.feed.feedshared.service;
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
+import com.samsamhajo.deepground.feed.feed.service.FeedMediaService;
+import com.samsamhajo.deepground.feed.feedshared.dto.SharedFeedRequest;
+import com.samsamhajo.deepground.feed.feedshared.entity.SharedFeed;
+import com.samsamhajo.deepground.feed.feedshared.exception.SharedFeedErrorCode;
+import com.samsamhajo.deepground.feed.feedshared.exception.SharedFeedException;
+import com.samsamhajo.deepground.feed.feedshared.model.FetchSharedFeedResponse;
+import com.samsamhajo.deepground.feed.feedshared.repository.SharedFeedRepository;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.exception.MemberErrorCode;
+import com.samsamhajo.deepground.member.exception.MemberException;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SharedFeedServiceTest {
+
+    private SharedFeedRepository sharedFeedRepository;
+    private FeedRepository feedRepository;
+    private MemberRepository memberRepository;
+    private FeedMediaService feedMediaService;
+    private SharedFeedService sharedFeedService;
+
+    private static final String TEST_CONTENT = "테스트 피드 내용입니다.";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "테스트유저";
+
+    @BeforeEach
+    void setUp() {
+        sharedFeedRepository = mock(SharedFeedRepository.class);
+        feedRepository = mock(FeedRepository.class);
+        memberRepository = mock(MemberRepository.class);
+        feedMediaService = mock(FeedMediaService.class);
+        sharedFeedService = new SharedFeedService(
+                sharedFeedRepository,
+                feedRepository,
+                memberRepository,
+                feedMediaService
+        );
+    }
+
+    @Test
+    @DisplayName("공유 피드 생성 성공")
+    void createSharedFeedSuccess() {
+        // given
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed originFeed = Feed.of(TEST_CONTENT, testMember);
+        Feed newFeed = Feed.of(TEST_CONTENT, testMember);
+        SharedFeed sharedFeed = SharedFeed.of(newFeed, originFeed, testMember);
+        
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(originFeed, "id", 1L);
+        ReflectionTestUtils.setField(newFeed, "id", 2L);
+        
+        SharedFeedRequest request = new SharedFeedRequest();
+        ReflectionTestUtils.setField(request, "originFeedId", 1L);
+        ReflectionTestUtils.setField(request, "content", TEST_CONTENT);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(feedRepository.getById(1L)).thenReturn(originFeed);
+        when(feedRepository.save(any(Feed.class))).thenReturn(newFeed);
+        when(sharedFeedRepository.save(any(SharedFeed.class))).thenReturn(sharedFeed);
+
+        // when
+        SharedFeed result = sharedFeedService.createSharedFeed(request, 1L);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(memberRepository).findById(1L);
+        verify(feedRepository).getById(1L);
+        verify(feedRepository).save(any(Feed.class));
+        verify(sharedFeedRepository).save(any(SharedFeed.class));
+    }
+
+    @Test
+    @DisplayName("공유 피드 생성 실패 - 존재하지 않는 회원")
+    void createSharedFeedFailWithInvalidMember() {
+        // given
+        SharedFeedRequest request = new SharedFeedRequest();
+        ReflectionTestUtils.setField(request, "originFeedId", 1L);
+        ReflectionTestUtils.setField(request, "content", TEST_CONTENT);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> sharedFeedService.createSharedFeed(request, 1L))
+                .isInstanceOf(MemberException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("공유 피드 조회 성공")
+    void getSharedFeedResponseSuccess() {
+        // given
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed originFeed = Feed.of(TEST_CONTENT, testMember);
+        Feed newFeed = Feed.of(TEST_CONTENT, testMember);
+        SharedFeed sharedFeed = SharedFeed.of(newFeed, originFeed, testMember);
+
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(originFeed, "id", 1L);
+        ReflectionTestUtils.setField(newFeed, "id", 2L);
+        ReflectionTestUtils.setField(sharedFeed, "id", 1L);
+        ReflectionTestUtils.setField(originFeed, "createdAt", LocalDateTime.now());
+        ReflectionTestUtils.setField(newFeed, "createdAt", LocalDateTime.now());
+
+        when(sharedFeedRepository.getOrNullByFeedId(2L)).thenReturn(sharedFeed);
+        when(feedMediaService.findAllMediaIdsByFeedId(1L)).thenReturn(List.of(1L, 2L));
+
+        // when
+        FetchSharedFeedResponse response = sharedFeedService.getSharedFeedResponse(2L);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getFeedId()).isEqualTo(1L);
+        assertThat(response.getMemberId()).isEqualTo(1L);
+        assertThat(response.getMemberName()).isEqualTo(TEST_NICKNAME);
+        assertThat(response.getContent()).isEqualTo(TEST_CONTENT);
+        assertThat(response.getMediaIds()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("공유 피드 조회 실패 - 존재하지 않는 공유 피드")
+    void getSharedFeedResponseFailWithNotFound() {
+        // given
+        when(sharedFeedRepository.getOrNullByFeedId(1L)).thenReturn(null);
+
+        // when
+        FetchSharedFeedResponse response = sharedFeedService.getSharedFeedResponse(1L);
+
+        // then
+        assertThat(response).isNull();
+    }
+
+    @Test
+    @DisplayName("원본 피드별 공유 수 조회 성공")
+    void countSharedFeedByOriginFeedIdSuccess() {
+        // given
+        when(sharedFeedRepository.countAllByOriginFeedId(1L)).thenReturn(5);
+
+        // when
+        int count = sharedFeedService.countSharedFeedByOriginFeedId(1L);
+
+        // then
+        assertThat(count).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("피드 ID로 공유 피드 조회 성공")
+    void findByFeedIdSuccess() {
+        // given
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        Feed originFeed = Feed.of(TEST_CONTENT, testMember);
+        Feed newFeed = Feed.of(TEST_CONTENT, testMember);
+        SharedFeed sharedFeed = SharedFeed.of(newFeed, originFeed, testMember);
+
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+        ReflectionTestUtils.setField(originFeed, "id", 1L);
+        ReflectionTestUtils.setField(newFeed, "id", 2L);
+        ReflectionTestUtils.setField(sharedFeed, "id", 1L);
+
+        when(sharedFeedRepository.getByFeedId(2L)).thenReturn(sharedFeed);
+
+        // when
+        SharedFeed foundSharedFeed = sharedFeedService.findByFeedId(2L);
+
+        // then
+        assertThat(foundSharedFeed).isNotNull();
+        assertThat(foundSharedFeed.getId()).isEqualTo(1L);
+        assertThat(foundSharedFeed.getFeed().getId()).isEqualTo(2L);
+        assertThat(foundSharedFeed.getOriginFeed().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("피드 ID로 공유 피드 조회 실패 - 존재하지 않는 공유 피드")
+    void findByFeedIdFailWithNotFound() {
+        // given
+        when(sharedFeedRepository.getByFeedId(1L))
+                .thenThrow(new SharedFeedException(SharedFeedErrorCode.SHARED_FEED_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> sharedFeedService.findByFeedId(1L))
+                .isInstanceOf(SharedFeedException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SharedFeedErrorCode.SHARED_FEED_NOT_FOUND);
+    }
+} 


### PR DESCRIPTION
## 📌 개요

피드 답글 목록 조회하기 구현

## 🛠️ 작업 내용
- [ ] 피드 답글 목록 조회하기 API 구현
- [ ] 피드 답글 미디어 조회하기 API 구현
- [ ] #231


### 작업 결과
- DB 실제적용 확인
- 멤버 좋아요 시 `liked = true`로 적용되는 것 확인
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/de821a27-3b48-4d76-bc49-51bf2ce40888" />


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
테스트 코드는 추후 PR에서 변경됩니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

closing #231 