### PR TITLE
[Feature] 스터디 그룹 목록 페이지네이션 조회 기능 및 TechTag 필터링 추가

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
@@ -45,7 +45,7 @@ public class StudyGroupController {
   public ResponseEntity<SuccessResponse<?>> searchStudyGroups(
       @ModelAttribute StudyGroupSearchRequest request
   ) {
-    GlobalLogger.info("스터디 목록 검색 요청", request.getKeyword(), request.getGroupStatus());
+    GlobalLogger.info("스터디 목록 검색 요청", request.getKeyword(), request.getGroupStatus(), request.getTechTags());
 
     var response = studyGroupService.searchStudyGroups(request);
     return ResponseEntity

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
@@ -27,7 +27,7 @@ public class StudyGroupDetailResponse {
         .id(group.getId())
         .title(group.getTitle())
         .explanation(group.getExplanation())
-        .writer(group.getMember().getNickname())
+        .writer(group.getCreator().getNickname())
         .memberCount(group.getMembers().size())
         .groupLimit(group.getGroupMemberCount())
         .location(group.getStudyLocation())

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupParticipationResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupParticipationResponse.java
@@ -19,7 +19,7 @@ public class StudyGroupParticipationResponse {
     return StudyGroupParticipationResponse.builder()
         .studyGroupId(studyGroup.getId())
         .title(studyGroup.getTitle())
-        .createdBy(studyGroup.getMember().getNickname())
+        .createdBy(studyGroup.getCreator().getNickname())
         .participatedAt(participatedAt)
         .build();
   }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
@@ -1,30 +1,59 @@
 package com.samsamhajo.deepground.studyGroup.dto;
 
-import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.TechTag;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
 
 @Getter
 @Builder
 public class StudyGroupResponse {
   private Long id;
   private String title;
-  private String explanation;
-  private GroupStatus groupStatus;
-  private LocalDate recruitEndDate;
-  private String studyLocation;
+  private String description;
+  private String period;
+  private String recruitmentPeriod;
+  private Set<TechTag> tags;
+  private Integer maxMembers;
+  private Integer currentMembers;
+  private OrganizerDto organizer;
+  private Boolean isOnline;
+  private String location;
+
+  @Getter
+  @Builder
+  public static class OrganizerDto {
+    private String name;
+    private String avatar;
+  }
 
   public static StudyGroupResponse from(StudyGroup group) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    Member creator = group.getCreator();
+
     return StudyGroupResponse.builder()
         .id(group.getId())
         .title(group.getTitle())
-        .explanation(group.getExplanation())
-        .groupStatus(group.getGroupStatus())
-        .recruitEndDate(group.getRecruitEndDate())
-        .studyLocation(group.getStudyLocation())
+        .description(group.getExplanation())
+        .period(group.getStudyStartDate().format(formatter) + " ~ " + group.getStudyEndDate().format(formatter))
+        .recruitmentPeriod(group.getRecruitStartDate().format(formatter) + " ~ " + group.getRecruitEndDate().format(formatter))
+        .tags(group.getTechTags())
+        .maxMembers(group.getGroupMemberCount())
+        .currentMembers(group.getMembers().size()) // 현재 참여 인원
+        .organizer(
+            OrganizerDto.builder()
+                .name(creator.getNickname())
+                .avatar("/placeholder.svg?height=40&width=40") // 실제 아바타 경로 설정 가능
+                .build()
+        )
+        .isOnline(!group.getIsOffline())
+        .location(group.getStudyLocation())
         .build();
   }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupSearchRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupSearchRequest.java
@@ -1,6 +1,8 @@
 package com.samsamhajo.deepground.studyGroup.dto;
 
 import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
+import com.samsamhajo.deepground.studyGroup.entity.TechTag;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.PageRequest;
@@ -14,13 +16,15 @@ public class StudyGroupSearchRequest {
   private final GroupStatus groupStatus;
   private final int page;
   private final int size;
+  private final Set<TechTag> techTags; // 추가됨
 
   @Builder
-  public StudyGroupSearchRequest(String keyword, GroupStatus groupStatus, int page, int size) {
+  public StudyGroupSearchRequest(String keyword, GroupStatus groupStatus, int page, int size, Set<TechTag> techTags) {
     this.keyword = keyword;
     this.groupStatus = groupStatus;
     this.page = page;
     this.size = size;
+    this.techTags = techTags;
   }
 
   public Pageable toPageable() {

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -60,15 +60,15 @@ public class StudyGroup extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Set<TechTag> techTags = new HashSet<>();
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    private Member creator;
 
 
     @OneToOne(fetch = FetchType.LAZY)
     private ChatRoom chatRoom;
 
-    @OneToMany(mappedBy = "studyGroup")
+    @OneToMany(mappedBy = "studyGroup", fetch = FetchType.EAGER)
     private final Set<StudyGroupMember> members = new HashSet<>();
 
     @OneToMany(mappedBy = "studyGroup")
@@ -88,7 +88,7 @@ public class StudyGroup extends BaseEntity {
         this.recruitStartDate = recruitStartDate;
         this.recruitEndDate = recruitEndDate;
         this.groupMemberCount = groupMemberCount;
-        this.member = member;
+        this.creator = member;
         this.isOffline = isOffline;
         this.studyLocation = studyLocation;
         this.techTags = techTags;

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAdminViewService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAdminViewService.java
@@ -24,7 +24,7 @@ public class StudyGroupAdminViewService {
     StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
         .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
 
-    if (!studyGroup.getMember().getId().equals(requester.getId())) {
+    if (!studyGroup.getCreator().getId().equals(requester.getId())) {
       throw new AccessDeniedException("해당 스터디 그룹의 생성자가 아닙니다.");
     }
 

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupDeleteService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupDeleteService.java
@@ -18,7 +18,7 @@ public class StudyGroupDeleteService {
     var studyGroup = studyGroupRepository.findById(studyGroupId)
         .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
 
-    if (!studyGroup.getMember().getId().equals(requester.getId())) {
+    if (!studyGroup.getCreator().getId().equals(requester.getId())) {
       throw new IllegalArgumentException("스터디 생성자만 삭제할 수 있습니다.");
     }
 

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupInviteService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupInviteService.java
@@ -25,7 +25,7 @@ public class StudyGroupInviteService {
     StudyGroup group = studyGroupRepository.findById(request.getStudyGroupId())
         .orElseThrow(() -> new IllegalArgumentException("스터디 그룹이 존재하지 않습니다."));
 
-    if (!group.getMember().getId().equals(inviter.getId())) {
+    if (!group.getCreator().getId().equals(inviter.getId())) {
       throw new SecurityException("스터디 생성자만 초대할 수 있습니다.");
     }
 

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupKickService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupKickService.java
@@ -23,7 +23,7 @@ public class StudyGroupKickService {
     StudyGroup group = studyGroupRepository.findById(request.getStudyGroupId())
         .orElseThrow(() -> new StudyGroupNotFoundException(request.getStudyGroupId()));
 
-    if (!group.getMember().getId().equals(requester.getId())) {
+    if (!group.getCreator().getId().equals(requester.getId())) {
       throw new IllegalArgumentException("스터디장만 강퇴할 수 있습니다.");
     }
 

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryService.java
@@ -29,7 +29,7 @@ public class StudyGroupMemberQueryService {
         .map(member -> StudyGroupMemberSummary.builder()
             .memberId(member.getMember().getId())
             .nickname(member.getMember().getNickname())
-            .isOwner(group.getMember().getId().equals(member.getMember().getId()))
+            .isOwner(group.getCreator().getId().equals(member.getMember().getId()))
             .joinedAt(member.getCreatedAt())
             .build())
         .toList();


### PR DESCRIPTION
## 📌 개요

* 스터디 그룹 목록을 페이지네이션 방식으로 조회할 수 있는 기능을 추가했습니다.
* 기존 `keyword`, `groupStatus` 필터링 외에 `techTags` 필터 조건을 추가했습니다.
* QueryDSL을 사용하지 않고 JPQL 기반 커스텀 쿼리를 작성하여 필터링 기능을 구현했습니다.

---

## 🛠️ 작업 내용
- [x] `StudyGroupSearchRequest`에 `techTags` 필드 추가
- [x] `StudyGroupRepository`에 `searchWithFilters(...)` JPQL 메서드 추가
- [x] `StudyGroupService`에서 모든 조건 통합하여 조회 로직 개선
- [x] `StudyGroupResponse` DTO를 통해 결과 구조 정리
- [x] `StudyGroupController`의 `/search` API 로깅 개선

### 🔍 스터디 목록 조건 검색 및 필터링

* `groupStatus`, `keyword`, `techTags`를 기준으로 필터링 조건에 따라 목록 조회
* `DISTINCT` 및 `LEFT JOIN`을 통해 중복 없이 결과 수집
---

## 📌 차후 계획 (Optional)

* 인기순/최신순 정렬 기준 확장
* `techTags` 외의 지역 기반 필터링 (`studyLocation`) 추가 예정
* `cursor-based pagination` 도입 여부 논의

---

## 📌 테스트 케이스
- [x] 다양한 필터 조합으로 페이지네이션 정상 동작 확인
- [x] `techTags` 파라미터가 없을 때 전체 조회되는지 확인
- [x] `groupStatus`, `keyword` null/empty 상태 처리 확인
- [x] 응답 구조에 필요한 필드가 정상 포함되는지 확인

### 📌 기타 참고 사항
- QueryDSL 없이 JPQL만으로 구현된 필터링 구조이기 때문에, 조건이 많아질 경우 쿼리 복잡도에 주의가 필요합니다.
- 프론트에서 `techTags`는 `?techTags=JAVA&techTags=SPRING` 형태로 전송하면 됩니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #277