### PR TITLE
[Refactor] 캘린더 도메인 @AuthenticationPrincipal 기반 사용자 ID 처리 리팩토링

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/controller/MemberStudyScheduleController.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/controller/MemberStudyScheduleController.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.calendar.controller;
 
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.calendar.dto.MemberScheduleCalendarResponseDto;
 import com.samsamhajo.deepground.calendar.dto.MemberScheduleDetailResponseDto;
 import com.samsamhajo.deepground.calendar.dto.MemberStudyScheduleRequestDto;
@@ -11,6 +12,7 @@ import com.samsamhajo.deepground.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,11 +24,13 @@ public class MemberStudyScheduleController {
 
     private final MemberStudyScheduleService memberStudyScheduleService;
 
-    @GetMapping("/member/{memberId}")
-    public ResponseEntity<SuccessResponse<List<MemberScheduleCalendarResponseDto>>> findMemberStudySchedulesByMemberId(
-            @PathVariable Long memberId
+    @GetMapping
+    public ResponseEntity<SuccessResponse<List<MemberScheduleCalendarResponseDto>>> findMemberStudySchedules(
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        List<MemberScheduleCalendarResponseDto> memberStudySchedules = memberStudyScheduleService.findAllByMemberId(memberId);
+        Long userId = userDetails.getMember().getId();
+
+        List<MemberScheduleCalendarResponseDto> memberStudySchedules = memberStudyScheduleService.findAllByMemberId(userId);
 
         return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_FOUND.getStatus())
                 .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_FOUND, memberStudySchedules));
@@ -34,9 +38,12 @@ public class MemberStudyScheduleController {
 
     @GetMapping("/{memberStudyScheduleId}")
     public ResponseEntity<SuccessResponse<MemberScheduleDetailResponseDto>> getScheduleByMemberScheduleId(
-            @PathVariable Long memberStudyScheduleId
+            @PathVariable Long memberStudyScheduleId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        MemberScheduleDetailResponseDto responseDto = memberStudyScheduleService.getScheduleByMemberScheduleId(memberStudyScheduleId);
+        Long userId = userDetails.getMember().getId();
+
+        MemberScheduleDetailResponseDto responseDto = memberStudyScheduleService.getScheduleByMemberScheduleId(memberStudyScheduleId, userId);
 
         return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_FOUND.getStatus())
                 .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_FOUND, responseDto));
@@ -45,9 +52,12 @@ public class MemberStudyScheduleController {
     @PatchMapping("/{memberStudyScheduleId}")
     public ResponseEntity<SuccessResponse<MemberStudyScheduleResponseDto>> updateByMemberScheduleId(
             @PathVariable Long memberStudyScheduleId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody MemberStudyScheduleRequestDto requestDto
     ) {
-        MemberStudyScheduleResponseDto responseDto = memberStudyScheduleService.updateMemberStudySchedule(memberStudyScheduleId, requestDto);
+        Long userId = userDetails.getMember().getId();
+
+        MemberStudyScheduleResponseDto responseDto = memberStudyScheduleService.updateMemberStudySchedule(memberStudyScheduleId, userId, requestDto);
         return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_UPDATED.getStatus())
                 .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_UPDATED, responseDto));
     }

--- a/src/main/java/com/samsamhajo/deepground/calendar/controller/StudyScheduleController.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/controller/StudyScheduleController.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.calendar.controller;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.calendar.dto.StudyScheduleRequestDto;
 import com.samsamhajo.deepground.calendar.dto.StudyScheduleResponseDto;
 import com.samsamhajo.deepground.calendar.exception.ScheduleSuccessCode;
@@ -8,6 +9,7 @@ import com.samsamhajo.deepground.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,9 +24,12 @@ public class StudyScheduleController {
     @PostMapping("/schedules")
     public ResponseEntity<SuccessResponse<StudyScheduleResponseDto>> createSchedule(
             @PathVariable Long studyGroupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody StudyScheduleRequestDto requestDto
     ) {
-        StudyScheduleResponseDto responseDto = studyScheduleService.createStudySchedule(studyGroupId, requestDto);
+        Long userId = userDetails.getMember().getId();
+
+        StudyScheduleResponseDto responseDto = studyScheduleService.createStudySchedule(studyGroupId, userId, requestDto);
         return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_CREATED.getStatus())
                 .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_CREATED, responseDto));
     }
@@ -41,10 +46,13 @@ public class StudyScheduleController {
     @PatchMapping("/schedules/{scheduleId}")
     public ResponseEntity<SuccessResponse<StudyScheduleResponseDto>> updateSchedule(
             @PathVariable Long studyGroupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long scheduleId,
             @Valid @RequestBody StudyScheduleRequestDto requestDto
     ) {
-        StudyScheduleResponseDto responseDto = studyScheduleService.updateStudySchedule(studyGroupId, scheduleId, requestDto);
+        Long userId = userDetails.getMember().getId();
+
+        StudyScheduleResponseDto responseDto = studyScheduleService.updateStudySchedule(studyGroupId, userId, scheduleId, requestDto);
         return ResponseEntity.status(ScheduleSuccessCode.SCHEDULE_UPDATED.getStatus())
                 .body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_UPDATED, responseDto));
     }
@@ -52,9 +60,12 @@ public class StudyScheduleController {
     @DeleteMapping("/schedules/{scheduleId}")
     public ResponseEntity<Void> deleteSchedule(
             @PathVariable Long studyGroupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long scheduleId
     ) {
-        studyScheduleService.deleteStudySchedule(studyGroupId, scheduleId);
+        Long userId = userDetails.getMember().getId();
+
+        studyScheduleService.deleteStudySchedule(studyGroupId, userId, scheduleId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleErrorCode.java
@@ -15,10 +15,20 @@ public enum ScheduleErrorCode implements ErrorCode {
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 일정을 찾을 수 없습니다."),
     MISMATCHED_GROUP(HttpStatus.FORBIDDEN, "해당 스케줄은 요청한 스터디 그룹에 속하지 않습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버를 찾을 수 없습니다."),
-    CANNOT_SET_DETAILS_WITHOUT_ATTENDANCE(HttpStatus.BAD_REQUEST,"참석 여부를 먼저 선택해야 중요 여부와 메모를 입력할 수 있습니다.");
+    CANNOT_SET_DETAILS_WITHOUT_ATTENDANCE(HttpStatus.BAD_REQUEST,"참석 여부를 먼저 선택해야 중요 여부와 메모를 입력할 수 있습니다."),
+    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "해당 스터디 그룹의 생성자가 아닙니다.");
 
 
     private final HttpStatus status;
     private final String message;
 
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/exception/ScheduleSuccessCode.java
@@ -15,4 +15,13 @@ public enum ScheduleSuccessCode implements SuccessCode {
     private final HttpStatus status;
     private final String message;
 
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
 }


### PR DESCRIPTION
## 📌 개요

* 스터디 스케줄 및 멤버 스터디 스케줄 기능 전반에 대해 AuthenticationPrincipal 기반 인증 방식으로 리팩토링하였으며, 테스트 코드 및 Swagger 문서도 이에 맞게 수정하였습니다.

## 🛠️ 작업 내용
- @AuthenticationPrincipal 기반으로 사용자 인증 처리 방식 변경
- MemberStudyScheduleService 등 주요 서비스에서 권한 검증 로직 보강
- Swagger 문서 수정 및 정상 반영 여부 확인 완료


## 📌 차후 계획 (Optional)

* (작업한 코드가 추후 우리 프로젝트에 어떤 영향을 끼칠지, 앞으로 PR계획을 설명해주세요)



## 📌 테스트 케이스
- 로그인한 사용자의 스터디 일정 전체 조회 성공/실패
- 스터디 일정 상세 조회 성공/실패 (존재하지 않는 일정 ID)
- 참석 여부/중요 여부/메모 업데이트 성공

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---
closes #281 