### PR TITLE
[Refactor]  친구 컨트롤러 @AuthenticationPripical 주입객체 Member -> CustomUserDetail로 리팩토링

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/Exception/FriendErrorCode.java
@@ -14,7 +14,7 @@ public enum FriendErrorCode implements ErrorCode {
     BLANK_EMAIL(HttpStatus.BAD_REQUEST, "친구요청을 보낼 이메일을 입력해주세요"),
     ALREADY_FRIEND(HttpStatus.BAD_REQUEST, "이미 친구로 등록된 사용자입니다."),
     INVALID_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "친구 요청이 존재하지 않습니다"),
-    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "다른 사용자의 친구 요청은 수락할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "본인의 친구 관계만 삭제할 수 있습니다."),
     REQUEST_ALREADY_RECEIVED(HttpStatus.BAD_REQUEST, "상대방이 이미 친구 요청을 보냈습니다"),
     INVALID_FRIEND(HttpStatus.BAD_REQUEST,"존재하지 않은 친구입니다");
 

--- a/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.friend.controller;
 
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.friend.Dto.FriendDto;
 import com.samsamhajo.deepground.friend.Dto.FriendRequestDto;
 import com.samsamhajo.deepground.friend.Exception.FriendSuccessCode;
@@ -11,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,16 +27,20 @@ public class FriendController {
 
     @PostMapping("/request")
     public ResponseEntity<SuccessResponse> requestFriend(@RequestBody @Valid FriendRequestDto dto,
-                                                         @AuthenticationPrincipal Member member) {
-        Long friendId = friendService.sendFriendRequest(member.getId(), dto.getReceiverEmail());
+                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long memberId = userDetails.getMember().getId();
+        Long friendId = friendService.sendFriendRequest(memberId, dto.getReceiverEmail());
         return ResponseEntity
                         .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_REQUEST,friendId));
     }
 
 
     @GetMapping("/sent")
-    public ResponseEntity<SuccessResponse<List<FriendDto>>> getSentFriendRequests(@AuthenticationPrincipal Member member) {
-        List<FriendDto> sentList = friendService.findSentFriendRequest(member.getId());
+    public ResponseEntity<SuccessResponse<List<FriendDto>>> getSentFriendRequests( @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long memberId = userDetails.getMember().getId();
+        List<FriendDto> sentList = friendService.findSentFriendRequest(memberId);
         return ResponseEntity.ok(
                 SuccessResponse.of(FriendSuccessCode.FRIEND_SENT_LIST_FOUND, sentList));
     }
@@ -42,32 +48,37 @@ public class FriendController {
 
     @PatchMapping("/sent/{friendId}/cancel")
     public ResponseEntity<SuccessResponse> cancelFriendRequest(@PathVariable Long friendId,
-                                                               @AuthenticationPrincipal Member member){
-        friendService.cancelFriendRequest(friendId, member.getId());
+                                                               @AuthenticationPrincipal CustomUserDetails userDetails){
+        Long memberId = userDetails.getMember().getId();
+        friendService.cancelFriendRequest(friendId, memberId);
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_CANCEL,friendId));
 
     }
 
     @GetMapping("/receive")
-    public ResponseEntity<SuccessResponse<List<FriendDto>>> getReceiveFriendRequests(@AuthenticationPrincipal Member member) {
-        List<FriendDto> receiveList = friendService.findFriendReceive(member.getId());
+    public ResponseEntity<SuccessResponse<List<FriendDto>>> getReceiveFriendRequests( @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long memberId = userDetails.getMember().getId();
+        List<FriendDto> receiveList = friendService.findFriendReceive(memberId);
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_RECEIVE_LIST_FOUND, receiveList));
     }
 
     @PatchMapping("/receive/{friendId}/accept")
     public ResponseEntity<SuccessResponse> acceptFriendRequest(@PathVariable Long friendId,
-                                                               @AuthenticationPrincipal Member member){
-        Long result = friendService.acceptFriendRequest(friendId, member.getId());
+                                                               @AuthenticationPrincipal CustomUserDetails userDetails){
+        Long memberId = userDetails.getMember().getId();
+        Long result = friendService.acceptFriendRequest(friendId, memberId);
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_ACCEPT,result));
     }
 
     @PatchMapping("/receive/{friendId}/refusal")
     public ResponseEntity<SuccessResponse> refusalFriendRequest(@PathVariable Long friendId,
-                                                                @AuthenticationPrincipal Member member){
-        friendService.refusalFriendRequest(friendId,member.getId());
+                                                                @AuthenticationPrincipal CustomUserDetails userDetails){
+        Long memberId = userDetails.getMember().getId();
+        friendService.refusalFriendRequest(friendId,memberId);
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_REFUSAL,friendId));
 
@@ -75,24 +86,29 @@ public class FriendController {
 
     @PostMapping("/from-profile/{receiverId}")
     public ResponseEntity<SuccessResponse> requestProfileFriend(@PathVariable Long receiverId,
-                                                                @AuthenticationPrincipal Member member) {
-        Long friendId = friendService.sendProfileFriendRequest(member.getId(), receiverId);
+                                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMember().getId();
+        Long friendId = friendService.sendProfileFriendRequest(memberId, receiverId);
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_REQUEST,friendId));
     }
 
     @DeleteMapping("/{friendId}")
-    public ResponseEntity<SuccessResponse> deleteFriend(@PathVariable Long friendId) {
+    public ResponseEntity<SuccessResponse> deleteFriend(@PathVariable Long friendId,
+                                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        friendService.deleteFriendById(friendId);
+        Long memberId = userDetails.getMember().getId();
+        friendService.deleteFriendByMemberId(friendId, memberId);
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_DELETE, friendId));
     }
 
     @GetMapping
-    public  ResponseEntity<SuccessResponse<List<FriendDto>>> getFriendList(@AuthenticationPrincipal Member member){
-        List<FriendDto> friends = friendService.getFriendByMemberId(member.getId());
+    public  ResponseEntity<SuccessResponse<List<FriendDto>>> getFriendList (@AuthenticationPrincipal CustomUserDetails userDetails){
+
+        Long memberId = userDetails.getMember().getId();
+        List<FriendDto> friends = friendService.getFriendByMemberId(memberId);
         return ResponseEntity
                 .ok(SuccessResponse.of(FriendSuccessCode.FRIEND_SUCCESS_GET_LIST,friends));
     }

--- a/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
+++ b/src/main/java/com/samsamhajo/deepground/friend/service/FriendService.java
@@ -171,11 +171,17 @@ public class FriendService {
 
 
     @Transactional
-    public void deleteFriendById(Long friendId) {
+    public void deleteFriendByMemberId(Long friendId, Long memberId) {
 
         Friend friend = friendRepository.findById(friendId)
                 .orElseThrow(() -> new FriendException(FriendErrorCode.INVALID_FRIEND));
 
+        boolean isRequester = friend.getRequestMember().getId().equals(memberId);
+        boolean isReceiver = friend.getReceiveMember().getId().equals(memberId);
+
+        if (!isRequester && !isReceiver) {
+            throw new FriendException(FriendErrorCode.UNAUTHORIZED_ACCESS);
+        }
         friend.softDelete();
     }
 
@@ -192,4 +198,6 @@ public class FriendService {
                 })
                 .toList();
     }
+
+
 }

--- a/src/main/java/com/samsamhajo/deepground/member/controller/MemberController.java
+++ b/src/main/java/com/samsamhajo/deepground/member/controller/MemberController.java
@@ -21,9 +21,10 @@ public class MemberController {
     private final MemberService memberService;
 
     @PutMapping("/{memberId}/profile")
-    public ResponseEntity<SuccessResponse> editMemberProfile(@RequestParam Long memberId,
-        @RequestBody @Valid MemberProfileDto memberprofile) {
+    public ResponseEntity<SuccessResponse> editMemberProfile( @AuthenticationPrincipal CustomUserDetails userDetails,
+                                                              @RequestBody @Valid MemberProfileDto memberprofile) {
 
+        Long memberId = userDetails.getMember().getId();
         MemberProfileDto profile = memberService.editMemberProfile(memberId, memberprofile);
         return ResponseEntity
             .ok(SuccessResponse.of(ProfileSuccessCode.PROFILE_SUCCESS_CODE,profile));

--- a/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendsTest.java
+++ b/src/test/java/com/samsamhajo/deepground/Friend/FriendService/FriendsTest.java
@@ -3,6 +3,8 @@ package com.samsamhajo.deepground.Friend.FriendService;
 
 
 import com.samsamhajo.deepground.friend.Dto.FriendDto;
+import com.samsamhajo.deepground.friend.Exception.FriendErrorCode;
+import com.samsamhajo.deepground.friend.Exception.FriendException;
 import com.samsamhajo.deepground.friend.entity.Friend;
 import com.samsamhajo.deepground.friend.repository.FriendRepository;
 import com.samsamhajo.deepground.friend.service.FriendService;
@@ -58,16 +60,20 @@ public class FriendsTest {
     }
 
     @Test
-    public void 친구_삭제_성공() throws Exception {
-        //given
-        Long friendId = friendService.sendFriendRequest(requester.getId(), receiver.getEmail());
-        friendService.acceptFriendRequest(friendId, receiver.getId());
+    public void 친구_삭제_성공() {
+        // given
+        Long requesterId = requester.getId(); // 로그인 사용자
+        Long receiverId = receiver.getId();
 
-        //when
-        friendService.deleteFriendById(friendId);
+        Long friendId = friendService.sendFriendRequest(requesterId, receiver.getEmail());
+        friendService.acceptFriendRequest(friendId, receiverId);
 
+        // when
+        friendService.deleteFriendByMemberId(friendId, requesterId);
+
+        // then
         Friend deletedFriend = friendRepository.findById(friendId)
-                .orElseThrow(() -> new RuntimeException("삭제된 친구가 DB에 존재하지 않음"));
+                .orElseThrow(() -> new FriendException(FriendErrorCode.INVALID_FRIEND));
 
         assertTrue(deletedFriend.isDeleted());
     }


### PR DESCRIPTION
## 📌 개요
@AuthenticationPrincipal 주입 객체를 기존 Member에서 UserDetails로 변경했습니다. 추가적으로 친구삭제 서비스 로직에 사용자 인증 로직을 추가 했습니다

## 🛠️ 작업 내용
-@AuthenticationPrincipal 주입 객체를 기존 Member에서 UserDetails로 변경
- 친구삭제 서비스 로직에 사용자 인증 로직을 추가
- 친구 삭제 테스트 코드 변경

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 없음
- 코드 스타일 및 컨벤션 준수
- 기존 테스트 통과 여부 확인

Closes #283