### PR TITLE
[Refactor] 피드 도메인 @AuthenticationPrincipal 기반 사용자 ID 처리 리팩토링

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedLikeController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedLikeController.java
@@ -1,19 +1,13 @@
 package com.samsamhajo.deepground.feed.feed.controller;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.exception.FeedSuccessCode;
-import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
-import com.samsamhajo.deepground.feed.feed.model.FeedListResponse;
-import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
 import com.samsamhajo.deepground.feed.feed.service.FeedLikeService;
-import com.samsamhajo.deepground.feed.feed.service.FeedService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,13 +17,12 @@ public class FeedLikeController {
 
     private final FeedLikeService feedLikeService;
 
-    private final Long DEV_MEMBER_ID = 1L;
-
     @PostMapping("/{feedId}/like")
     public ResponseEntity<SuccessResponse<Feed>> createFeedLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable ("feedId") Long feedId){
 
-        feedLikeService.feedLikeIncrease(feedId, DEV_MEMBER_ID);
+        feedLikeService.feedLikeIncrease(feedId, userDetails.getMember());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedSuccessCode.FEED_LIKED));
@@ -37,9 +30,10 @@ public class FeedLikeController {
 
     @DeleteMapping("/{feedId}/like")
     public ResponseEntity<SuccessResponse<Feed>> deleteFeedLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable ("feedId") Long feedId){
 
-        feedLikeService.feedLikeDecrease(feedId, DEV_MEMBER_ID);
+        feedLikeService.feedLikeDecrease(feedId, userDetails.getMember().getId());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedSuccessCode.FEED_UNLIKED));

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedMediaController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/controller/FeedMediaController.java
@@ -18,8 +18,6 @@ public class FeedMediaController {
 
     private final FeedMediaService feedMediaService;
 
-
-    // 피드 이미지 아이디로 이미지 불러오기
     @GetMapping("/{mediaId}")
     public ResponseEntity<InputStreamResource> viewImage(@PathVariable("mediaId") Long mediaId) {
         FeedMediaResponse feedMediaResponse =

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeService.java
@@ -8,8 +8,6 @@ import com.samsamhajo.deepground.feed.feed.exception.FeedException;
 import com.samsamhajo.deepground.feed.feed.repository.FeedLikeRepository;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
 import com.samsamhajo.deepground.member.entity.Member;
-import com.samsamhajo.deepground.member.exception.MemberErrorCode;
-import com.samsamhajo.deepground.member.exception.MemberException;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,16 +18,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class FeedLikeService {
 
     private final FeedRepository feedRepository;
-    private final MemberRepository memberRepository;
     private final FeedLikeRepository feedLikeRepository;
 
     @Transactional
-    public void feedLikeIncrease(Long feedId, Long memberId) {
-        increaseValidate(feedId, memberId);
+    public void feedLikeIncrease(Long feedId, Member member) {
+        increaseValidate(feedId, member.getId());
 
         Feed feed = feedRepository.getById(feedId);
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         FeedLike feedLike = FeedLike.of(feed, member);
 
@@ -39,7 +34,7 @@ public class FeedLikeService {
     @Transactional
     public void feedLikeDecrease(Long feedId, Long memberId) {
         // 이미 0 이거나 음수인 경우 취소하려 할 때, 예외 발생 
-        validateDecrease(feedId);
+        decreaseValidate(feedId);
 
         FeedLike feedLike = feedLikeRepository.getByFeedIdAndMemberId(feedId, memberId);
 
@@ -58,7 +53,7 @@ public class FeedLikeService {
         return feedLikeRepository.existsByFeedIdAndMemberId(feedId, memberId);
     }
 
-    private void validateDecrease(Long feedId) {
+    private void decreaseValidate(Long feedId) {
         if(countFeedLikeByFeedId(feedId) <= 0){
             throw new FeedException(FeedErrorCode.FEED_LIKE_MINUS_NOT_ALLOWED);
         }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -3,15 +3,15 @@ package com.samsamhajo.deepground.feed.feed.service;
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
 import com.samsamhajo.deepground.feed.feed.exception.FeedException;
-import com.samsamhajo.deepground.feed.feed.model.*;
+import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
+import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
+import com.samsamhajo.deepground.feed.feed.model.FetchFeedResponse;
+import com.samsamhajo.deepground.feed.feed.model.FetchFeedsResponse;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
 import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentService;
 import com.samsamhajo.deepground.feed.feedshared.model.FetchSharedFeedResponse;
-import com.samsamhajo.deepground.member.entity.Member;
-import com.samsamhajo.deepground.member.exception.MemberErrorCode;
-import com.samsamhajo.deepground.member.exception.MemberException;
-import com.samsamhajo.deepground.member.repository.MemberRepository;
 import com.samsamhajo.deepground.feed.feedshared.service.SharedFeedService;
+import com.samsamhajo.deepground.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,19 +25,15 @@ public class FeedService {
 
     private final FeedRepository feedRepository;
     private final FeedMediaService feedMediaService;
-    private final MemberRepository memberRepository;
     private final FeedCommentService feedCommentService;
     private final FeedLikeService feedLikeService;
     private final SharedFeedService sharedFeedService;
 
     @Transactional
-    public Feed createFeed(FeedCreateRequest request, Long memberId) {
+    public Feed createFeed(FeedCreateRequest request, Member member) {
         if (!StringUtils.hasText(request.getContent())) {
             throw new FeedException(FeedErrorCode.INVALID_FEED_CONTENT);
         }
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         Feed feed = Feed.of(request.getContent(), member);
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentController.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.feed.feedcomment.controller;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.feed.feedcomment.exception.FeedCommentSuccessCode;
 import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentCreateRequest;
 import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentUpdateRequest;
@@ -9,6 +10,7 @@ import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,13 +19,13 @@ import org.springframework.web.bind.annotation.*;
 public class FeedCommentController {
 
     private final FeedCommentService feedCommentService;
-    private final Long DEV_MEMBER_ID = 1L;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse<?>> createFeedComment(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @ModelAttribute FeedCommentCreateRequest request) {
 
-        feedCommentService.createFeedComment(request, DEV_MEMBER_ID);
+        feedCommentService.createFeedComment(request, userDetails.getMember());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedCommentSuccessCode.FEED_COMMENT_CREATED));
@@ -52,9 +54,11 @@ public class FeedCommentController {
 
     @GetMapping("/list/{feedId}")
     public ResponseEntity<SuccessResponse<FetchFeedCommentsResponse>> getFeedComments(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("feedId") Long feedId) {
 
-        FetchFeedCommentsResponse response = feedCommentService.getFeedComments(feedId, DEV_MEMBER_ID);
+        FetchFeedCommentsResponse response =
+                feedCommentService.getFeedComments(feedId, userDetails.getMember().getId());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedCommentSuccessCode.FEED_COMMENT_LIST_FETCHED, response));

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentLikeController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/controller/FeedCommentLikeController.java
@@ -1,10 +1,12 @@
 package com.samsamhajo.deepground.feed.feedcomment.controller;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.feed.feedcomment.exception.FeedCommentSuccessCode;
 import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentLikeService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,13 +16,12 @@ public class FeedCommentLikeController {
 
     private final FeedCommentLikeService feedCommentLikeService;
 
-    private final Long DEV_MEMBER_ID = 1L;
-
     @PostMapping("/{feedCommentId}/like")
     public ResponseEntity<SuccessResponse<?>> createFeedLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("feedCommentId") Long feedCommentId) {
 
-        feedCommentLikeService.feedLikeIncrease(feedCommentId, DEV_MEMBER_ID);
+        feedCommentLikeService.feedLikeIncrease(feedCommentId, userDetails.getMember());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedCommentSuccessCode.FEED_COMMENT_LIKED));
@@ -28,9 +29,10 @@ public class FeedCommentLikeController {
 
     @DeleteMapping("/{feedCommentId}/like")
     public ResponseEntity<SuccessResponse<?>> deleteFeedLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("feedCommentId") Long feedCommentId) {
 
-        feedCommentLikeService.feedLikeDecrease(feedCommentId, DEV_MEMBER_ID);
+        feedCommentLikeService.feedLikeDecrease(feedCommentId, userDetails.getMember().getId());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedCommentSuccessCode.FEED_COMMENT_DISLIKED));

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentLikeService.java
@@ -20,16 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class FeedCommentLikeService {
 
     private final FeedCommentRepository feedCommentRepository;
-    private final MemberRepository memberRepository;
     private final FeedCommentLikeRepository feedCommentLikeRepository;
 
     @Transactional
-    public void feedLikeIncrease(Long feedId, Long memberId) {
-        increaseValidate(feedId, memberId);
+    public void feedLikeIncrease(Long feedId, Member member) {
+        increaseValidate(feedId, member.getId());
 
         FeedComment feedComment = feedCommentRepository.getById(feedId);
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         FeedCommentLike feedCommentLike = FeedCommentLike.of(feedComment, member);
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentService.java
@@ -12,9 +12,6 @@ import com.samsamhajo.deepground.feed.feedcomment.model.FetchFeedCommentsRespons
 import com.samsamhajo.deepground.feed.feedcomment.repository.FeedCommentRepository;
 import com.samsamhajo.deepground.feed.feedreply.service.FeedReplyService;
 import com.samsamhajo.deepground.member.entity.Member;
-import com.samsamhajo.deepground.member.exception.MemberErrorCode;
-import com.samsamhajo.deepground.member.exception.MemberException;
-import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,18 +27,14 @@ public class FeedCommentService {
     private final FeedCommentRepository feedCommentRepository;
     private final FeedCommentMediaService feedCommentMediaService;
     private final FeedRepository feedRepository;
-    private final MemberRepository memberRepository;
     private final FeedReplyService feedReplyService;
     private final FeedCommentLikeService feedCommentLikeService;
 
     @Transactional
-    public FeedComment createFeedComment(FeedCommentCreateRequest request, Long memberId) {
+    public FeedComment createFeedComment(FeedCommentCreateRequest request, Member member) {
         if (!StringUtils.hasText(request.getContent())) {
             throw new FeedCommentException(FeedCommentErrorCode.INVALID_FEED_COMMENT_CONTENT);
         }
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         Feed feed = feedRepository.getById(request.getFeedId());
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyController.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.feed.feedreply.controller;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.feed.feedreply.exception.FeedReplySuccessCode;
 import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyCreateRequest;
 import com.samsamhajo.deepground.feed.feedreply.model.FeedReplyUpdateRequest;
@@ -9,6 +10,7 @@ import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,13 +19,13 @@ import org.springframework.web.bind.annotation.*;
 public class FeedReplyController {
 
     private final FeedReplyService feedReplyService;
-    private final Long DEV_MEMBER_ID = 1L;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse<?>> createFeedReply(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @ModelAttribute FeedReplyCreateRequest request) {
 
-        feedReplyService.createFeedReply(request, DEV_MEMBER_ID);
+        feedReplyService.createFeedReply(request, userDetails.getMember());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_CREATED));
@@ -52,9 +54,11 @@ public class FeedReplyController {
 
     @GetMapping("/list/{feedReplyId}")
     public ResponseEntity<SuccessResponse<?>> getFeedReplies(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("feedReplyId") Long feedCommentId) {
 
-        FetchFeedRepliesResponse response = feedReplyService.getFeedReplies(feedCommentId, DEV_MEMBER_ID);
+        FetchFeedRepliesResponse response =
+                feedReplyService.getFeedReplies(feedCommentId, userDetails.getMember().getId());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_LIST_FETCHED, response));

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyLikeController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/controller/FeedReplyLikeController.java
@@ -1,10 +1,12 @@
 package com.samsamhajo.deepground.feed.feedreply.controller;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.feed.feedreply.exception.FeedReplySuccessCode;
 import com.samsamhajo.deepground.feed.feedreply.service.FeedReplyLikeService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,13 +15,13 @@ import org.springframework.web.bind.annotation.*;
 public class FeedReplyLikeController {
 
     private final FeedReplyLikeService feedReplyLikeService;
-    private final Long DEV_MEMBER_ID = 1L;
 
     @PostMapping("/{feedReplyId}/like")
     public ResponseEntity<SuccessResponse<?>> createFeedReplyLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("feedReplyId") Long feedReplyId) {
 
-        feedReplyLikeService.feedReplyLikeIncrease(feedReplyId, DEV_MEMBER_ID);
+        feedReplyLikeService.feedReplyLikeIncrease(feedReplyId, userDetails.getMember());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_LIKED));
@@ -27,9 +29,10 @@ public class FeedReplyLikeController {
 
     @DeleteMapping("/{feedReplyId}/like")
     public ResponseEntity<SuccessResponse<?>> deleteFeedReplyLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("feedReplyId") Long feedReplyId) {
 
-        feedReplyLikeService.feedReplyLikeDecrease(feedReplyId, DEV_MEMBER_ID);
+        feedReplyLikeService.feedReplyLikeDecrease(feedReplyId, userDetails.getMember().getId());
 
         return ResponseEntity
                 .ok(SuccessResponse.of(FeedReplySuccessCode.FEED_REPLY_DISLIKED));

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyLikeService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyLikeService.java
@@ -7,9 +7,6 @@ import com.samsamhajo.deepground.feed.feedreply.exception.FeedReplyException;
 import com.samsamhajo.deepground.feed.feedreply.repository.FeedReplyLikeRepository;
 import com.samsamhajo.deepground.feed.feedreply.repository.FeedReplyRepository;
 import com.samsamhajo.deepground.member.entity.Member;
-import com.samsamhajo.deepground.member.exception.MemberErrorCode;
-import com.samsamhajo.deepground.member.exception.MemberException;
-import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,16 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class FeedReplyLikeService {
 
     private final FeedReplyRepository feedReplyRepository;
-    private final MemberRepository memberRepository;
     private final FeedReplyLikeRepository feedReplyLikeRepository;
 
     @Transactional
-    public void feedReplyLikeIncrease(Long feedReplyId, Long memberId) {
-        increaseValidate(feedReplyId, memberId);
+    public void feedReplyLikeIncrease(Long feedReplyId, Member member) {
+        increaseValidate(feedReplyId, member.getId());
 
         FeedReply feedReply = feedReplyRepository.getById(feedReplyId);
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         FeedReplyLike feedReplyLike = FeedReplyLike.of(feedReply, member);
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyService.java
@@ -30,18 +30,14 @@ public class FeedReplyService {
 
     private final FeedCommentRepository feedCommentRepository;
     private final FeedReplyRepository feedReplyRepository;
-    private final MemberRepository memberRepository;
     private final FeedReplyMediaService feedReplyMediaService;
     private final FeedReplyLikeService feedReplyLikeService;
 
     @Transactional
-    public FeedComment createFeedReply(FeedReplyCreateRequest request, Long memberId) {
+    public FeedComment createFeedReply(FeedReplyCreateRequest request, Member member) {
         if (!StringUtils.hasText(request.getContent())) {
             throw new FeedCommentException(FeedCommentErrorCode.INVALID_FEED_COMMENT_CONTENT);
         }
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         FeedComment feedComment = feedCommentRepository.getById(request.getFeedCommentId());
 

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/controller/SharedFeedController.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/controller/SharedFeedController.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.feed.feedshared.controller;
 
+import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.feed.feedshared.dto.SharedFeedRequest;
 import com.samsamhajo.deepground.feed.feedshared.exception.SharedFeedSuccessCode;
 import com.samsamhajo.deepground.feed.feedshared.service.SharedFeedService;
@@ -7,6 +8,7 @@ import com.samsamhajo.deepground.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,12 +17,12 @@ import org.springframework.web.bind.annotation.*;
 public class SharedFeedController {
 
     private final SharedFeedService sharedFeedService;
-    private final Long DEV_MEMBER_ID = 1L;
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createSharedFeed(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody SharedFeedRequest request) {
 
-        sharedFeedService.createSharedFeed(request, DEV_MEMBER_ID);
+        sharedFeedService.createSharedFeed(request, userDetails.getMember());
         
         return ResponseEntity.ok(SuccessResponse.of(SharedFeedSuccessCode.FEED_SHARED));
     }

--- a/src/main/java/com/samsamhajo/deepground/feed/feedshared/service/SharedFeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feedshared/service/SharedFeedService.java
@@ -1,16 +1,13 @@
 package com.samsamhajo.deepground.feed.feedshared.service;
 
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
-import com.samsamhajo.deepground.feed.feedshared.model.FetchSharedFeedResponse;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
 import com.samsamhajo.deepground.feed.feed.service.FeedMediaService;
 import com.samsamhajo.deepground.feed.feedshared.dto.SharedFeedRequest;
 import com.samsamhajo.deepground.feed.feedshared.entity.SharedFeed;
+import com.samsamhajo.deepground.feed.feedshared.model.FetchSharedFeedResponse;
 import com.samsamhajo.deepground.feed.feedshared.repository.SharedFeedRepository;
 import com.samsamhajo.deepground.member.entity.Member;
-import com.samsamhajo.deepground.member.exception.MemberErrorCode;
-import com.samsamhajo.deepground.member.exception.MemberException;
-import com.samsamhajo.deepground.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,14 +21,11 @@ public class SharedFeedService {
 
     private final SharedFeedRepository sharedFeedRepository;
     private final FeedRepository feedRepository;
-    private final MemberRepository memberRepository;
     private final FeedMediaService feedMediaService;
 
     @Transactional
-    public SharedFeed createSharedFeed(SharedFeedRequest request, Long memberId) {
+    public SharedFeed createSharedFeed(SharedFeedRequest request, Member member) {
         Feed originFeed = feedRepository.getById(request.getOriginFeedId());
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         Feed feed = Feed.of(request.getContent(), member);
         feedRepository.save(feed);

--- a/src/test/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentLikeServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentLikeServiceTest.java
@@ -10,7 +10,6 @@ import com.samsamhajo.deepground.feed.feedcomment.repository.FeedCommentReposito
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.exception.MemberErrorCode;
 import com.samsamhajo.deepground.member.exception.MemberException;
-import com.samsamhajo.deepground.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,8 +32,6 @@ class FeedCommentLikeServiceTest {
 
     @Mock
     private FeedCommentRepository feedCommentRepository;
-    @Mock
-    private MemberRepository memberRepository;
     @Mock
     private FeedCommentLikeRepository feedCommentLikeRepository;
 
@@ -69,12 +66,11 @@ class FeedCommentLikeServiceTest {
     void feedLikeIncreaseSuccess() {
         // given
         when(feedCommentRepository.getById(1L)).thenReturn(testFeedComment);
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
         when(feedCommentLikeRepository.existsByFeedCommentIdAndMemberId(1L, 1L)).thenReturn(false);
         when(feedCommentLikeRepository.save(any(FeedCommentLike.class))).thenReturn(testFeedCommentLike);
 
         // when
-        feedCommentLikeService.feedLikeIncrease(1L, 1L);
+        feedCommentLikeService.feedLikeIncrease(1L, testMember);
 
         // then
         verify(feedCommentLikeRepository).save(any(FeedCommentLike.class));
@@ -87,7 +83,7 @@ class FeedCommentLikeServiceTest {
         when(feedCommentLikeRepository.existsByFeedCommentIdAndMemberId(1L, 1L)).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> feedCommentLikeService.feedLikeIncrease(1L, 1L))
+        assertThatThrownBy(() -> feedCommentLikeService.feedLikeIncrease(1L, testMember))
                 .isInstanceOf(FeedCommentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", FeedCommentErrorCode.FEED_COMMENT_LIKE_ALREADY_EXISTS);
     }
@@ -95,11 +91,8 @@ class FeedCommentLikeServiceTest {
     @Test
     @DisplayName("피드 댓글 좋아요 증가 실패 - 존재하지 않는 회원")
     void feedLikeIncreaseFailWithInvalidMember() {
-        // given
-        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
-
         // when & then
-        assertThatThrownBy(() -> feedCommentLikeService.feedLikeIncrease(1L, 1L))
+        assertThatThrownBy(() -> feedCommentLikeService.feedLikeIncrease(1L, testMember))
                 .isInstanceOf(MemberException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
     }

--- a/src/test/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedcomment/service/FeedCommentServiceTest.java
@@ -7,7 +7,6 @@ import com.samsamhajo.deepground.feed.feedcomment.exception.FeedCommentErrorCode
 import com.samsamhajo.deepground.feed.feedcomment.exception.FeedCommentException;
 import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentCreateRequest;
 import com.samsamhajo.deepground.feed.feedcomment.model.FeedCommentUpdateRequest;
-import com.samsamhajo.deepground.feed.feedcomment.model.FetchFeedCommentsResponse;
 import com.samsamhajo.deepground.feed.feedcomment.repository.FeedCommentRepository;
 import com.samsamhajo.deepground.feed.feedreply.service.FeedReplyService;
 import com.samsamhajo.deepground.member.entity.Member;
@@ -41,8 +40,6 @@ class FeedCommentServiceTest {
     private FeedCommentMediaService feedCommentMediaService;
     @Mock
     private FeedRepository feedRepository;
-    @Mock
-    private MemberRepository memberRepository;
     @Mock
     private FeedReplyService feedReplyService;
     @Mock
@@ -84,12 +81,11 @@ class FeedCommentServiceTest {
         // given
         FeedCommentCreateRequest request = new FeedCommentCreateRequest(1L, TEST_CONTENT, List.of(testImage));
 
-        when(memberRepository.findById(1L)).thenReturn(java.util.Optional.of(testMember));
         when(feedRepository.getById(1L)).thenReturn(testFeed);
         when(feedCommentRepository.save(any(FeedComment.class))).thenReturn(testFeedComment);
 
         // when
-        FeedComment createdComment = feedCommentService.createFeedComment(request, 1L);
+        FeedComment createdComment = feedCommentService.createFeedComment(request, testMember);
 
         // then
         assertThat(createdComment).isNotNull();
@@ -104,7 +100,7 @@ class FeedCommentServiceTest {
         FeedCommentCreateRequest request = new FeedCommentCreateRequest(1L, "", List.of());
 
         // when & then
-        assertThatThrownBy(() -> feedCommentService.createFeedComment(request, 1L))
+        assertThatThrownBy(() -> feedCommentService.createFeedComment(request, testMember))
                 .isInstanceOf(FeedCommentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", FeedCommentErrorCode.INVALID_FEED_COMMENT_CONTENT);
     }
@@ -114,10 +110,9 @@ class FeedCommentServiceTest {
     void createFeedCommentFailWithInvalidMember() {
         // given
         FeedCommentCreateRequest request = new FeedCommentCreateRequest(1L, TEST_CONTENT, List.of());
-        when(memberRepository.findById(1L)).thenReturn(java.util.Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> feedCommentService.createFeedComment(request, 1L))
+        assertThatThrownBy(() -> feedCommentService.createFeedComment(request, testMember))
                 .isInstanceOf(MemberException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
     }

--- a/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyLikeServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyLikeServiceTest.java
@@ -10,7 +10,6 @@ import com.samsamhajo.deepground.feed.feedreply.repository.FeedReplyRepository;
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.exception.MemberErrorCode;
 import com.samsamhajo.deepground.member.exception.MemberException;
-import com.samsamhajo.deepground.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,9 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,8 +37,6 @@ class FeedReplyLikeServiceTest {
     @InjectMocks
     private FeedReplyLikeService feedReplyLikeService;
 
-    @Mock
-    private MemberRepository memberRepository;
 
     private static final String TEST_CONTENT = "테스트 답글 내용입니다.";
     private static final String TEST_EMAIL = "test@example.com";
@@ -74,10 +68,9 @@ class FeedReplyLikeServiceTest {
         when(feedReplyRepository.getById(1L)).thenReturn(testFeedReply);
         when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(1L, 1L)).thenReturn(false);
         when(feedReplyLikeRepository.save(any(FeedReplyLike.class))).thenReturn(testFeedReplyLike);
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
 
         // when
-        feedReplyLikeService.feedReplyLikeIncrease(1L, 1L);
+        feedReplyLikeService.feedReplyLikeIncrease(1L, testMember);
 
         // then
         verify(feedReplyLikeRepository).save(any(FeedReplyLike.class));
@@ -90,7 +83,7 @@ class FeedReplyLikeServiceTest {
         when(feedReplyLikeRepository.existsByFeedReplyIdAndMemberId(1L, 1L)).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeIncrease(1L, 1L))
+        assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeIncrease(1L, testMember))
                 .isInstanceOf(FeedReplyException.class)
                 .hasMessage(FeedReplyErrorCode.FEED_REPLY_LIKE_ALREADY_EXISTS.getMessage());
     }
@@ -103,7 +96,7 @@ class FeedReplyLikeServiceTest {
                 .thenThrow(new MemberException(MemberErrorCode.INVALID_MEMBER_ID));
 
         // when & then
-        assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeIncrease(1L, 1L))
+        assertThatThrownBy(() -> feedReplyLikeService.feedReplyLikeIncrease(1L, testMember))
                 .isInstanceOf(MemberException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
     }

--- a/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feedreply/service/FeedReplyServiceTest.java
@@ -82,12 +82,11 @@ class FeedReplyServiceTest {
         // given
         FeedReplyCreateRequest request = new FeedReplyCreateRequest(1L, TEST_CONTENT, List.of(testImage));
 
-        when(memberRepository.findById(1L)).thenReturn(java.util.Optional.of(testMember));
         when(feedCommentRepository.getById(1L)).thenReturn(testFeedComment);
         when(feedReplyRepository.save(any(FeedReply.class))).thenReturn(testFeedReply);
 
         // when
-        FeedComment result = feedReplyService.createFeedReply(request, 1L);
+        FeedComment result = feedReplyService.createFeedReply(request, testMember);
 
         // then
         assertThat(result).isNotNull();
@@ -102,7 +101,7 @@ class FeedReplyServiceTest {
         FeedReplyCreateRequest request = new FeedReplyCreateRequest(1L, "", List.of());
 
         // when & then
-        assertThatThrownBy(() -> feedReplyService.createFeedReply(request, 1L))
+        assertThatThrownBy(() -> feedReplyService.createFeedReply(request, testMember))
                 .isInstanceOf(FeedCommentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", FeedCommentErrorCode.INVALID_FEED_COMMENT_CONTENT);
     }
@@ -115,7 +114,7 @@ class FeedReplyServiceTest {
         when(memberRepository.findById(1L)).thenReturn(java.util.Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> feedReplyService.createFeedReply(request, 1L))
+        assertThatThrownBy(() -> feedReplyService.createFeedReply(request, testMember))
                 .isInstanceOf(MemberException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.INVALID_MEMBER_ID);
     }


### PR DESCRIPTION
## 📌 개요
피드 도메인 @AuthenticationPrincipal 기반 사용자 ID 처리 리팩토링

## 🛠️ 작업 내용
- [x] @AuthenticationPrincipal 어노테이션 사용
- [x] DEV_MEMBER_ID 제거
- [x] 서비스 로직에서 MemberRepository 의존성 제거 및 Member를 findById로 가져오는 로직 제거
- [x] 일부 서비스 구현부 메서드 파라미터 수정 Long -> Member
- [x] 리팩토링으로 인한 테스트코드 수정

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
스터디 그룹 쪽 테스트 코드에서 컴파일 에러가 나는 관계로.. 당장 테스트는 못돌려봤습니다
---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

closing #288 