### PR TITLE
[Feature] 스터디장 스터디 수락 기능 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
@@ -51,6 +51,7 @@ public class StudyGroupDetailResponse {
         )
         .comments(
             group.getComments().stream()
+                .distinct()
                 .map(comment -> CommentWithRepliesResponse.from(comment, replyMap.getOrDefault(comment.getId(), List.of())))
                 .toList()
         )

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
@@ -41,4 +41,14 @@ public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMemb
   Optional<StudyGroupMember> findByStudyGroupIdAndMemberId(Long studyGroupId, Long memberId);
 
   void deleteByStudyGroupIdAndMemberId(Long studyGroupId, Long memberId);
+
+  @Query("""
+  SELECT m FROM StudyGroupMember m
+  JOIN FETCH m.member
+  WHERE m.studyGroup.id = :studyGroupId
+    AND m.isAllowed = false
+    AND m.deleted = false
+  ORDER BY m.createdAt ASC
+""")
+  List<StudyGroupMember> findAllByStudyGroupIdAndIsAllowedFalse(@Param("studyGroupId") Long studyGroupId);
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAcceptService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupAcceptService.java
@@ -1,0 +1,44 @@
+package com.samsamhajo.deepground.studyGroup.service;
+
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
+import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupAcceptService {
+
+  private final StudyGroupRepository studyGroupRepository;
+  private final StudyGroupMemberRepository studyGroupMemberRepository;
+
+  @Transactional
+  public void acceptMember(Long studyGroupId, Long targetMemberId, Member requester) {
+    // 스터디 존재 확인
+    StudyGroup group = studyGroupRepository.findById(studyGroupId)
+        .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
+
+    // 요청자가 스터디장인지 확인
+    if (!group.getCreator().getId().equals(requester.getId())) {
+      throw new IllegalArgumentException("스터디장만 수락할 수 있습니다.");
+    }
+
+    // 신청자 존재 및 상태 확인
+    StudyGroupMember member = studyGroupMemberRepository
+        .findByStudyGroupIdAndMemberId(studyGroupId, targetMemberId)
+        .orElseThrow(() -> new IllegalArgumentException("신청자가 존재하지 않습니다."));
+
+    // 이미 수락된 경우 예외 처리
+    if (Boolean.TRUE.equals(member.getIsAllowed())) {
+      throw new IllegalStateException("이미 수락된 멤버입니다.");
+    }
+
+    // 상태 수락으로 변경
+    member.allowMember();
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryService.java
@@ -1,8 +1,10 @@
 package com.samsamhajo.deepground.studyGroup.service;
 
 
+import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupMemberSummary;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
 import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
@@ -31,6 +33,24 @@ public class StudyGroupMemberQueryService {
             .nickname(member.getMember().getNickname())
             .isOwner(group.getCreator().getId().equals(member.getMember().getId()))
             .joinedAt(member.getCreatedAt())
+            .build())
+        .toList();
+  }
+
+  public List<StudyGroupMemberSummary> getPendingApplicantsAsCreator(Long studyGroupId, Member requester) {
+    StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
+        .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
+
+    if (!studyGroup.getCreator().getId().equals(requester.getId())) {
+      throw new IllegalArgumentException("스터디장만 신청자 목록을 조회할 수 있습니다.");
+    }
+
+    List<StudyGroupMember> pending = studyGroupMemberRepository.findAllByStudyGroupIdAndIsAllowedFalse(studyGroupId);
+
+    return pending.stream()
+        .map(m -> StudyGroupMemberSummary.builder()
+            .memberId(m.getMember().getId())
+            .nickname(m.getMember().getNickname())
             .build())
         .toList();
   }


### PR DESCRIPTION

📌 개요
- 스터디장(스터디 생성자)이 대기 상태의 신청자를 수락할 수 있는 기능을 추가했습니다.
- 수락 시 해당 신청자는 정식 멤버(isAllowed = true)로 등록됩니다.

🛠️ 작업 내용
- 스터디 신청 수락 API 구현
- StudyGroupAcceptRequest DTO 정의
- StudyGroupAcceptService 생성 및 비즈니스 로직 분리
- 스터디장 권한 검증 로직 추가
- 중복 수락 방지
- 관련 이슈 번호 (#이슈번호)

🔹 주요 로직
- 요청자의 ID와 스터디 생성자의 ID를 비교하여 권한 확인
- 존재하지 않는 스터디 또는 멤버일 경우 예외 발생
- 이미 수락된 멤버는 다시 수락 불가

```
if (!Objects.equals(studyGroup.getCreator().getId(), requester.getId())) {
    throw new AccessDeniedException("스터디장만 수락할 수 있습니다.");
}
```
---

📌 기타 참고 사항
- 기존의 StudyGroupMember 엔티티 구조를 활용하여 최소 변경으로 구현
- 도메인 책임은 서비스 계층에서 처리하도록 분리
- 컨트롤러는 단순 위임만 담당

---

🙏🏻 리뷰어 참고사항
- 수락 조건 및 권한 검증 로직이 충분히 명확한지 확인 부탁드립니다.
- 중복 수락 방지 조건이 누락되지 않았는지 검토해주세요.
- 예외 처리 메시지나 응답 코드가 일관성 있게 적용되어 있는지 확인해주세요.

Closes #287