### PR TITLE
[Feature] 멤버스터디dto에 studyGroupId 필드 추가

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberScheduleCalendarResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/dto/MemberScheduleCalendarResponseDto.java
@@ -12,6 +12,7 @@ public class MemberScheduleCalendarResponseDto {
 
     private Long memberStudyScheduleId;
     private Long studyScheduleId;
+    private Long studyGroupId;
     private String title;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
@@ -19,9 +20,11 @@ public class MemberScheduleCalendarResponseDto {
 
     public static MemberScheduleCalendarResponseDto from(MemberStudySchedule schedule) {
         var ss = schedule.getStudySchedule();
+        var sg = ss.getStudyGroup();
         return MemberScheduleCalendarResponseDto.builder()
                 .memberStudyScheduleId(schedule.getId())
                 .studyScheduleId(ss.getId())
+                .studyGroupId(sg.getId())
                 .title(ss.getTitle())
                 .startTime(ss.getStartTime())
                 .endTime(ss.getEndTime())

--- a/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
@@ -13,6 +13,12 @@ public interface MemberStudyScheduleRepository extends JpaRepository<MemberStudy
 
     void deleteAllByStudyScheduleId(Long scheduleId);
 
-    @Query("SELECT mss FROM MemberStudySchedule mss JOIN FETCH mss.studySchedule WHERE mss.member.id = :memberId")
+    @Query("""
+    SELECT mss
+    FROM MemberStudySchedule mss
+    JOIN FETCH mss.studySchedule ss
+    JOIN FETCH ss.studyGroup
+    WHERE mss.member.id = :memberId
+    """)
     List<MemberStudySchedule> findAllByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## 📌 개요
- 멤버 스터디 일정 조회 시 StudyGroup ID도 같이 조회되도록 수정

## 🛠️ 작업 내용
- MemberScheduleCalendarResponseDto에 studyGroupId 필드 추가
- MemberStudyScheduleRepository에 fetch join 쿼리 적용
- from() 팩토리 메서드에서 studyGroupId 추출 로직 추가
- N+1 문제 콘솔 확인 완료


## 📌 차후 계획 (Optional)

- 프론트 연동 수정 예정



## 📌 테스트 케이스
- 기능 정상 동작 확인
- 코드 스타일 및 컨벤션 준수 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

closes #291 