### PR TITLE
[Refactor] StudyGroup의 getMember()를 getCreator()로 변경

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
@@ -150,7 +150,7 @@ public class StudyScheduleService {
         }
     }
     private void validateStudyLeader(Long userId, StudyGroup studyGroup) {
-        if (!studyGroup.getMember().getId().equals(userId)) {
+        if (!studyGroup.getCreator().getId().equals(userId)) {
             throw new ScheduleException(ScheduleErrorCode.UNAUTHORIZED_USER);
         }
     }

--- a/src/test/java/com/samsamhajo/deepground/calendar/service/StudyScheduleServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/calendar/service/StudyScheduleServiceTest.java
@@ -60,7 +60,7 @@ class StudyScheduleServiceTest {
 
         Member leader = mock(Member.class);
         when(leader.getId()).thenReturn(userId);
-        when(studyGroup.getMember()).thenReturn(leader);
+        when(studyGroup.getCreator()).thenReturn(leader);
     }
 
     @Test
@@ -168,7 +168,7 @@ class StudyScheduleServiceTest {
         Member notLeader = mock(Member.class);
         when(notLeader.getId()).thenReturn(9L);
 
-        when(studyGroup.getMember()).thenReturn(notLeader);
+        when(studyGroup.getCreator()).thenReturn(notLeader);
         when(studyGroupRepository.findById(anyLong())).thenReturn(Optional.of(studyGroup));
 
         // when & then
@@ -344,7 +344,7 @@ class StudyScheduleServiceTest {
         // given
         Member notLeader = mock(Member.class);
         when(notLeader.getId()).thenReturn(999L);
-        when(studyGroup.getMember()).thenReturn(notLeader);
+        when(studyGroup.getCreator()).thenReturn(notLeader);
         when(studyGroupRepository.findById(anyLong())).thenReturn(Optional.of(studyGroup));
 
         StudySchedule schedule = mock(StudySchedule.class);
@@ -403,7 +403,7 @@ class StudyScheduleServiceTest {
 
         Member notLeader = mock(Member.class);
         when(notLeader.getId()).thenReturn(999L);
-        when(studyGroup.getMember()).thenReturn(notLeader);
+        when(studyGroup.getCreator()).thenReturn(notLeader);
         when(studyGroup.getId()).thenReturn(studyGroupId);
 
         StudySchedule schedule = mock(StudySchedule.class);


### PR DESCRIPTION
## 📌 개요

스터디 그룹 리더를 반환하는 메서드명을 getMember() → getCreator()로 변경하여 의미 명확화

## 🛠️ 작업 내용
- StudyGroup 도메인의 getMember() 메서드명 변경


## 📌 차후 계획 (Optional)

* (작업한 코드가 추후 우리 프로젝트에 어떤 영향을 끼칠지, 앞으로 PR계획을 설명해주세요)


### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

closes #293 