### PR TITLE
[Fix] 도메인 엔티티 필드명 변경으로 인한 테스트코드 수정

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.studyGroup.dto;
 
 import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.entity.TechTag;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class StudyGroupResponse {
   private String description;
   private String period;
   private String recruitmentPeriod;
+  private GroupStatus groupStatus;
   private Set<TechTag> tags;
   private Integer maxMembers;
   private Integer currentMembers;
@@ -46,6 +48,7 @@ public class StudyGroupResponse {
         .tags(group.getTechTags())
         .maxMembers(group.getGroupMemberCount())
         .currentMembers(group.getMembers().size())
+        .groupStatus(group.getGroupStatus())
         .organizer(
             OrganizerDto.builder()
                 .name(creator.getNickname())

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepositoryTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepositoryTest.java
@@ -20,6 +20,7 @@
 //
 //
 //import java.time.LocalDate;
+//import java.util.HashSet;
 //import java.util.Optional;
 //
 //import static org.assertj.core.api.Assertions.*;
@@ -56,7 +57,8 @@
 //        10,
 //        writer,
 //        true,
-//        "강남"
+//        "강남",
+//        new HashSet<>()
 //    );
 //    savedGroup = studyGroupRepository.save(group);
 //    em.flush();
@@ -109,7 +111,8 @@
 //          5,
 //          creator,
 //          true,
-//          "강남"
+//          "강남",
+//          new HashSet<>()
 //      );
 //      group.changeGroupStatus(status);
 //      studyGroupRepository.save(group);

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupCommentServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupCommentServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -56,7 +57,8 @@ class StudyGroupCommentServiceTest extends IntegrationTestSupport {
         10,
         member,
         true,
-        "신촌"
+        "신촌",
+        new HashSet<>()
     );
     studyGroupRepository.save(group);
     this.studyGroupId = group.getId();

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupDeleteServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupDeleteServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,7 +40,8 @@ class StudyGroupDeleteServiceTest extends IntegrationTestSupport {
         null, "삭제 테스트 스터디", "설명",
         LocalDate.now(), LocalDate.now().plusDays(10),
         LocalDate.now(), LocalDate.now().plusDays(3),
-        5, owner, true, "강남"
+        5, owner, true, "강남",
+        new HashSet<>()
     );
     studyGroupRepository.save(group);
   }

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupInviteServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupInviteServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -41,7 +42,8 @@ class StudyGroupInviteServiceTest extends IntegrationTestSupport {
         null, "스터디", "소개",
         LocalDate.now(), LocalDate.now().plusDays(10),
         LocalDate.now(), LocalDate.now().plusDays(3),
-        5, owner, true, "강남"
+        5, owner, true, "강남",
+        new HashSet<>()
     );
     studyGroupRepository.save(group);
   }

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupJoinServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupJoinServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,7 +60,8 @@ class StudyGroupJoinServiceTest extends IntegrationTestSupport {
         5,
         writer,
         true,
-        "강남"
+        "강남",
+        new HashSet<>()
     );
     studyGroupRepository.save(studyGroup);
     em.flush();

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupKickServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupKickServiceTest.java
@@ -13,6 +13,7 @@ import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
 import java.time.LocalDate;
+import java.util.HashSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,8 @@ class StudyGroupKickServiceTest extends IntegrationTestSupport {
         null, "스터디", "소개",
         LocalDate.now(), LocalDate.now().plusDays(10),
         LocalDate.now(), LocalDate.now().plusDays(3),
-        5, owner, true, "강남"
+        5, owner, true, "강남",
+        new HashSet<>()
     );
     studyGroupRepository.save(group);
 

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupMemberQueryServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,7 +41,8 @@ class StudyGroupMemberQueryServiceTest extends IntegrationTestSupport {
         null, "테스트 스터디", "설명",
         LocalDate.now(), LocalDate.now().plusDays(5),
         LocalDate.now(), LocalDate.now().plusDays(1),
-        3, owner, true, "신촌"
+        3, owner, true, "신촌",
+        new HashSet<>()
     );
     studyGroupRepository.save(group);
 

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupParticipationServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupParticipationServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -51,7 +52,8 @@ class StudyGroupParticipationServiceTest extends IntegrationTestSupport {
           null, "참가 스터디 " + i, "설명",
           LocalDate.now(), LocalDate.now().plusDays(30),
           LocalDate.now(), LocalDate.now().plusDays(10),
-          5, creator, true, "서울"
+          5, creator, true, "서울",
+          new HashSet<>()
       );
       studyGroupRepository.save(group);
 
@@ -64,7 +66,8 @@ class StudyGroupParticipationServiceTest extends IntegrationTestSupport {
           null, "대기 스터디 " + i, "설명",
           LocalDate.now(), LocalDate.now().plusDays(30),
           LocalDate.now(), LocalDate.now().plusDays(10),
-          5, creator, true, "서울"
+          5, creator, true, "서울",
+          new HashSet<>()
       );
       studyGroupRepository.save(group);
 

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupReplyServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupReplyServiceTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -50,7 +51,8 @@ class StudyGroupReplyServiceTest extends IntegrationTestSupport {
         null, "스터디 제목", "설명",
         LocalDate.now().plusDays(1), LocalDate.now().plusDays(3),
         LocalDate.now(), LocalDate.now().plusDays(2),
-        5, commenter, true, "강남"
+        5, commenter, true, "강남",
+        new HashSet<>()
     );
     groupRepository.save(group);
 

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceDetailsTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceDetailsTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -55,7 +56,8 @@ class StudyGroupServiceDetailsTest extends IntegrationTestSupport {
         10,
         writer,
         true,
-        "강남"
+        "강남",
+        new HashSet<>()
     );
     studyGroupRepository.save(group);
 

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceIntegrationTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceIntegrationTest.java
@@ -68,7 +68,7 @@ class StudyGroupServiceIntegrationTest extends IntegrationTestSupport {
 
     StudyGroup group = savedGroup.get();
     assertThat(group.getTitle()).isEqualTo(request.getTitle());
-    assertThat(group.getMember().getId()).isEqualTo(creator.getId());
+    assertThat(group.getCreator().getId()).isEqualTo(creator.getId());
 
     Optional<StudyGroupMember> membership = studyGroupMemberRepository.findAll().stream()
         .filter(m -> m.getMember().getId().equals(creator.getId()) &&

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceMyListTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceMyListTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.springframework.test.context.TestPropertySource;
@@ -54,7 +55,8 @@ class StudyGroupServiceMyListTest extends IntegrationTestSupport {
           LocalDate.now().plusDays(30),
           LocalDate.now(),
           LocalDate.now().plusDays(5),
-          5, creator, true, "강남"
+          5, creator, true, "강남",
+          new HashSet<>()
       );
       if (i > 5) {
         group.changeGroupStatus(GroupStatus.COMPLETED);
@@ -70,7 +72,8 @@ class StudyGroupServiceMyListTest extends IntegrationTestSupport {
           LocalDate.now().plusDays(30),
           LocalDate.now(),
           LocalDate.now().plusDays(5),
-          5, otherUser, true, "신촌"
+          5, otherUser, true, "신촌",
+          new HashSet<>()
       );
       studyGroupRepository.save(group);
     });

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceSearchTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceSearchTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.stream.IntStream;
 import org.springframework.test.annotation.Rollback;
 
@@ -52,7 +53,8 @@ class StudyGroupServiceSearchTest extends IntegrationTestSupport {
           LocalDate.now().plusDays(30),
           LocalDate.now(),
           LocalDate.now().plusDays(5),
-          5, creator, true, "강남"
+          5, creator, true, "강남",
+          new HashSet<>()
       );
       group.changeGroupStatus(status);
       studyGroupRepository.save(group);


### PR DESCRIPTION
## 📌개요

스터디그룹 도메인의 테스트 코드에서 `StudyGroup` 엔티티 생성 시 발생하는 컴파일 오류를 수정했습니다. `StudyGroup.of()` 메서드의 시그니처가 변경되어 `Set<TechTag> techTags` 파라미터가 필수로 추가되었는데, 기존 테스트 코드에서는 이 파라미터가 누락되어 있었습니다.

## 📌 작업 내용
- [x] 스터디그룹 도메인의 모든 테스트 파일에서 `StudyGroup.of()` 호출 시 누락된 `techTags` 파라미터 추가
- [x] 12개 테스트 파일의 `StudyGroup` 객체 생성 코드 수정
- [x] 컴파일 오류 해결로 테스트 실행 가능하도록 개선

### 수정 내용 상세

모든 `StudyGroup.of()` 메서드 호출에서 다음과 같이 수정했습니다.

**수정 전:**
```java
StudyGroup.of(
    null, "스터디 제목", "설명",
    LocalDate.now().plusDays(1),
    LocalDate.now().plusDays(10),
    LocalDate.now(),
    LocalDate.now().plusDays(5),
    5, creator, true, "강남"
);
```

**수정 후:**
```java
StudyGroup.of(
    null, "스터디 제목", "설명",
    LocalDate.now().plusDays(1),
    LocalDate.now().plusDays(10),
    LocalDate.now(),
    LocalDate.now().plusDays(5),
    5, creator, true, "강남",
    new HashSet<>()  // techTags 파라미터 추가
);
```

## 📌차후 계획 (Optional)

- 스터디그룹 도메인의 테스트 커버리지 향상을 위해 실제 `TechTag` 값을 사용한 테스트 케이스 추가 고려
- 테스트 데이터의 다양성을 위해 다양한 기술 스택 조합을 테스트하는 시나리오 개발
- 통합 테스트에서 실제 비즈니스 로직 검증을 위한 더 구체적인 테스트 케이스 작성

## 📌테스트 케이스
- [x] 기능 정상 동작 확인 - 모든 테스트 파일에서 `StudyGroup` 객체 생성 성공
- [x] 새로운 의존성 추가 여부 확인 - 기존 `HashSet` 사용으로 추가 의존성 없음
- [x] 코드 스타일 및 컨벤션 준수 확인 - 기존 코드 스타일 유지
- [x] 기존 테스트 통과 여부 확인 - 컴파일 오류 해결로 테스트 실행 가능

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #299