### PR TITLE
[Feature] 파일 서버 AWS s3 연동 로직 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// AWS S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/samsamhajo/deepground/global/config/S3Config.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.samsamhajo.deepground.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("$cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey,secretKey);
+                return (AmazonS3Client) AmazonS3ClientBuilder
+                        .standard()
+                        .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                        .withRegion(region)
+                        .build();
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/global/config/S3Config.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/S3Config.java
@@ -18,7 +18,7 @@ public class S3Config {
     @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
 
-    @Value("$cloud.aws.region.static}")
+    @Value("${cloud.aws.region.static}")
     private String region;
 
     @Bean

--- a/src/main/java/com/samsamhajo/deepground/global/upload/S3Uploader.java
+++ b/src/main/java/com/samsamhajo/deepground/global/upload/S3Uploader.java
@@ -1,0 +1,85 @@
+package com.samsamhajo.deepground.global.upload;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.samsamhajo.deepground.global.upload.exception.UploadErrorCode;
+import com.samsamhajo.deepground.global.upload.exception.UploadException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3Uploader {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucket;
+
+    public String upload(MultipartFile multipartFile, String dirName){
+        File uploadFile = convert(multipartFile);
+        return upload(uploadFile, dirName);
+    }
+
+    private String upload(File uploadFile, String dirName) {
+        String fileName = dirName + "/" + changedImageName(uploadFile.getName());
+        String uploadImageUrl = putS3(uploadFile,fileName);
+        removeNewFile(uploadFile);
+
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucket, fileName,uploadFile)
+                        .withCannedAcl(CannedAccessControlList.PublicRead)
+                );
+        return amazonS3Client.getUrl(bucket,fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다");
+        }
+    }
+
+    private File convert(MultipartFile multipartFile) {
+        try {
+            String extension = getExtension(multipartFile.getOriginalFilename());
+            File tempFile = File.createTempFile("upload_", extension);
+
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                fos.write(multipartFile.getBytes());
+            }
+
+            return tempFile;
+        } catch (IOException e) {
+            throw new UploadException(UploadErrorCode.FILE_CONVERT_FAIL);
+        }
+    }
+
+    private String getExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            throw new UploadException(UploadErrorCode.INVALID_FILE_NAME);
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+
+    private String changedImageName(String originName) {
+        String random = UUID.randomUUID().toString();
+        return random + originName;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/global/upload/S3Uploader.java
+++ b/src/main/java/com/samsamhajo/deepground/global/upload/S3Uploader.java
@@ -43,7 +43,6 @@ public class S3Uploader {
     private String putS3(File uploadFile, String fileName) {
         amazonS3Client.putObject(
                 new PutObjectRequest(bucket, fileName,uploadFile)
-                        .withCannedAcl(CannedAccessControlList.PublicRead)
                 );
         return amazonS3Client.getUrl(bucket,fileName).toString();
     }
@@ -82,4 +81,6 @@ public class S3Uploader {
         String random = UUID.randomUUID().toString();
         return random + originName;
     }
+
+
 }

--- a/src/main/java/com/samsamhajo/deepground/global/upload/exception/UploadErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/global/upload/exception/UploadErrorCode.java
@@ -1,0 +1,25 @@
+package com.samsamhajo.deepground.global.upload.exception;
+
+import com.samsamhajo.deepground.global.error.core.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@AllArgsConstructor
+public enum UploadErrorCode implements ErrorCode {
+    FILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "파일 변환에 실패했습니다."),
+    INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "파일 이름이 유효하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[UPLOAD ERROR]" + message;
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/global/upload/exception/UploadException.java
+++ b/src/main/java/com/samsamhajo/deepground/global/upload/exception/UploadException.java
@@ -1,0 +1,8 @@
+package com.samsamhajo.deepground.global.upload.exception;
+
+import com.samsamhajo.deepground.global.error.core.BaseException;
+
+public class UploadException extends BaseException {
+
+    public UploadException(UploadErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/com/samsamhajo/deepground/member/Dto/MemberProfileDto.java
+++ b/src/main/java/com/samsamhajo/deepground/member/Dto/MemberProfileDto.java
@@ -2,21 +2,19 @@ package com.samsamhajo.deepground.member.Dto;
 
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.entity.MemberProfile;
-import com.samsamhajo.deepground.techStack.entity.MemberTechStack;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.validator.constraints.URL;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static ch.qos.logback.classic.spi.ThrowableProxyVO.build;
 
 @Setter
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class MemberProfileDto {
 

--- a/src/main/java/com/samsamhajo/deepground/member/controller/MemberController.java
+++ b/src/main/java/com/samsamhajo/deepground/member/controller/MemberController.java
@@ -9,9 +9,11 @@ import com.samsamhajo.deepground.member.exception.ProfileSuccessCode;
 import com.samsamhajo.deepground.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,14 +22,15 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @PutMapping("/profile")
-    public ResponseEntity<SuccessResponse<MemberProfileDto>> editMemberProfile( @AuthenticationPrincipal CustomUserDetails userDetails,
-                                                              @RequestBody @Valid MemberProfileDto memberprofile) {
+    @PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SuccessResponse<MemberProfileDto>> editMemberProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart("profile") @Valid MemberProfileDto memberProfileDto,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
 
         Long memberId = userDetails.getMember().getId();
-        MemberProfileDto profile = memberService.editMemberProfile(memberId, memberprofile);
-        return ResponseEntity
-            .ok(SuccessResponse.of(ProfileSuccessCode.PROFILE_SUCCESS_CODE,profile));
+        MemberProfileDto profile = memberService.editMemberProfile(memberId, memberProfileDto, profileImage);
 
+        return ResponseEntity.ok(SuccessResponse.of(ProfileSuccessCode.PROFILE_SUCCESS_CODE, profile));
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/qna/question/service/QuestionMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/qna/question/service/QuestionMediaService.java
@@ -1,5 +1,7 @@
 package com.samsamhajo.deepground.qna.question.service;
 
+import com.nimbusds.oauth2.sdk.util.CollectionUtils;
+import com.samsamhajo.deepground.global.upload.S3Uploader;
 import com.samsamhajo.deepground.media.MediaUtils;
 import com.samsamhajo.deepground.qna.question.entity.Question;
 import com.samsamhajo.deepground.qna.question.entity.QuestionMedia;
@@ -10,7 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static com.samsamhajo.deepground.media.MediaUtils.getExtension;
 
 
 @Service
@@ -19,17 +23,20 @@ import java.util.List;
 public class QuestionMediaService {
 
     private final QuestionMediaRepository questionMediaRepository;
+    private final S3Uploader s3Uploader;
 
     public void createQuestionMedia(Question question, List<MultipartFile> images) {
+        if (CollectionUtils.isEmpty(images)) return;
 
-        questionMediaRepository.saveAll(
-                images.stream()
-                        .map(image -> QuestionMedia.of(
-                                MediaUtils.generateMediaUrl(image),
-                                MediaUtils.getExtension(image),
-                                question))
-                        .toList()
-        );
+        List<QuestionMedia> mediaEntities = images.stream()
+                .map(image -> {
+                    String url = s3Uploader.upload(image, "question-media");
+                    String extension = getExtension(image.getOriginalFilename());
+                    return QuestionMedia.of(url, extension, question);
+                })
+                .collect(Collectors.toList());
+
+        questionMediaRepository.saveAll(mediaEntities);
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ api:
   version: v1
 
 spring:
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
   config:
     import: optional:file:./.env[.properties]
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -135,3 +135,18 @@ swagger:
 app:
   oauth2:
     authorized-redirect-uri: ${OAUTH2_AUTHORIZED_REDIRECT_URI}
+
+#AWS S3 관련 설정
+cloud:
+  aws:
+    s3:
+      bucketName: ${BUCKET_NAME}
+    credentials:
+      access-key: ${ACCESS_KEY}
+      secret-key: ${SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+

--- a/src/test/java/com/samsamhajo/deepground/member/service/ProfileTest.java
+++ b/src/test/java/com/samsamhajo/deepground/member/service/ProfileTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -90,8 +91,9 @@ public class ProfileTest {
                 .websiteUrl("https://new.dev")
                 .twitterUrl("https://twitter.com/new")
                 .build();
+
         //when
-        MemberProfileDto update = memberService.editMemberProfile(member.getId(), edit);
+        MemberProfileDto update = memberService.editMemberProfile(member.getId(), edit, null);
 
         //then
         assertEquals("https://example.com/new.jpg", update.getProfileImage());
@@ -118,7 +120,7 @@ public class ProfileTest {
 
         // when & then
         assertThrows(MemberException.class, () ->
-                memberService.editMemberProfile(invalidMemberId, dto));
+                memberService.editMemberProfile(invalidMemberId, dto,null));
     }
 
 }


### PR DESCRIPTION
## 📌 개요
- AWS S3 연동을 위한 설정 및 파일 업로드 유틸 클래스(S3Uploader)를 추가했습니다
## 🛠️ 작업 내용
- s3 관련 `builde.grade` 추가
- S3 관련 프로퍼티 및 yml 파일 설정
- S3Uploader 유틸 클래스 구현
- 예외 처리용 `UploadException`, `UploadErrorCode` 정의
- 피드 , 질문 , 댓글 관련 미디어 서비스 로직 리팩토링 (`FeedMediaService`,`AnswerMediaService`,`CommentMediaService`
- 프로필 편집 관련 로직 사진 업로드 로직 추가 (`editMemberProfile`,

## 📌 테스트 케이스
- 기능 정상 동작 
- 새로운 의존성 추가 (`build.gradle`,`application.yml`)
- 코드 스타일 및 컨벤션 준수
- 기존 테스트 통과
- 파일이 실제 AWS S3에 저장되는지 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
- 업로드 경로는 `dirName/UUID+파일명` 구조로 저장됨
- 현재는 공개 접근 권한으로 업로드됨 (추후 권한 설정 기능 고려 필요)
---
Close #303 