### PR TITLE
[Feature] 스터디 참여 상태 분기 로직 및 응답 필드 추가

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
@@ -54,11 +54,13 @@ public class StudyGroupController {
 
   @GetMapping("/{studyGroupId}")
   public ResponseEntity<SuccessResponse<?>> getStudyGroupDetail(
-      @PathVariable Long studyGroupId
+      @PathVariable Long studyGroupId,
+      @AuthenticationPrincipal CustomUserDetails customUserDetails
   ) {
     GlobalLogger.info("스터디 그룹 상세 조회 요청", studyGroupId);
+    Member member = customUserDetails.getMember();
 
-    var response = studyGroupService.getStudyGroupDetail(studyGroupId);
+    var response = studyGroupService.getStudyGroupDetail(studyGroupId, member.getId());
 
     return ResponseEntity
         .status(StudyGroupSuccessCode.READ_SUCCESS.getStatus())

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupDetailResponse.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.studyGroup.dto;
 
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMemberStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupReply;
 import java.time.LocalDate;
 import java.util.Map;
@@ -28,8 +29,9 @@ public class StudyGroupDetailResponse {
   private int commentCount;
   private List<String> participants;
   private List<CommentWithRepliesResponse> comments;
+  private StudyGroupMemberStatus memberStatus;
 
-  public static StudyGroupDetailResponse from(StudyGroup group, Map<Long, List<StudyGroupReply>> replyMap) {
+  public static StudyGroupDetailResponse from(StudyGroup group, Map<Long, List<StudyGroupReply>> replyMap, StudyGroupMemberStatus memberStatus) {
     return StudyGroupDetailResponse.builder()
         .id(group.getId())
         .title(group.getTitle())
@@ -44,6 +46,7 @@ public class StudyGroupDetailResponse {
         .studyStartDate(group.getStudyStartDate())
         .studyEndDate(group.getStudyEndDate())
         .commentCount(group.getComments().size())
+        .memberStatus(memberStatus)
         .participants(
             group.getMembers().stream()
                 .map(m -> m.getMember().getNickname())

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMemberStatus.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupMemberStatus.java
@@ -1,0 +1,7 @@
+package com.samsamhajo.deepground.studyGroup.entity;
+
+public enum StudyGroupMemberStatus {
+  NOT_APPLIED, // 스터디에 신청하지 않음
+  PENDING,     // 신청했으나 아직 승인되지 않음
+  APPROVED     // 신청했고 승인됨
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupCommentRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupCommentRepository.java
@@ -2,6 +2,8 @@ package com.samsamhajo.deepground.studyGroup.repository;
 
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StudyGroupCommentRepository extends JpaRepository<StudyGroupComment, Long> {
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupMemberRepository.java
@@ -40,8 +40,6 @@ public interface StudyGroupMemberRepository extends JpaRepository<StudyGroupMemb
 
   Optional<StudyGroupMember> findByStudyGroupIdAndMemberId(Long studyGroupId, Long memberId);
 
-  void deleteByStudyGroupIdAndMemberId(Long studyGroupId, Long memberId);
-
   @Query("""
   SELECT m FROM StudyGroupMember m
   JOIN FETCH m.member

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupReplyRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupReplyRepository.java
@@ -8,5 +8,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StudyGroupReplyRepository extends JpaRepository<StudyGroupReply, Long> {
-  List<StudyGroupReply> findAllByComment_IdOrderByCreatedAtAsc(Long commentId);
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -1,9 +1,7 @@
 package com.samsamhajo.deepground.studyGroup.repository;
 
-import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
-import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMember;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupReply;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -35,22 +33,6 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
       Pageable pageable
   );
 
-  Page<StudyGroup> findByGroupStatusAndTitleContainingIgnoreCaseOrGroupStatusAndExplanationContainingIgnoreCase(
-      GroupStatus status1, String titleKeyword,
-      GroupStatus status2, String explanationKeyword,
-      Pageable pageable
-  );
-
-  Page<StudyGroup> findByTitleContainingIgnoreCaseOrExplanationContainingIgnoreCase(
-      String titleKeyword, String explanationKeyword,
-      Pageable pageable
-  );
-
-  Page<StudyGroup> findByGroupStatus(
-      GroupStatus groupStatus,
-      Pageable pageable
-  );
-
   @Query("""
   SELECT DISTINCT sg FROM StudyGroup sg
   LEFT JOIN FETCH sg.creator
@@ -69,7 +51,5 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
   List<StudyGroupReply> findRepliesByCommentIds(@Param("commentIds") List<Long> commentIds);
 
   List<StudyGroup> findAllByCreator_IdOrderByCreatedAtDesc(Long memberId);
-
-
 
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -5,6 +5,7 @@ import com.samsamhajo.deepground.studyGroup.dto.StudyGroupParticipationResponse;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupMyListResponse;
 import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupComment;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupMemberStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupReply;
 import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupResponse;
@@ -39,7 +40,7 @@ public class StudyGroupService {
 
 
   @Transactional
-  public StudyGroupDetailResponse getStudyGroupDetail(Long studyGroupId) {
+  public StudyGroupDetailResponse getStudyGroupDetail(Long studyGroupId, Long memberId) {
     StudyGroup group = studyGroupRepository.findWithCreatorAndCommentsById(studyGroupId)
         .orElseThrow(() -> new StudyGroupNotFoundException(studyGroupId));
 
@@ -51,8 +52,19 @@ public class StudyGroupService {
 
     Map<Long, List<StudyGroupReply>> replyMap = replies.stream()
         .collect(Collectors.groupingBy(r -> r.getComment().getId()));
+    StudyGroupMemberStatus memberStatus = getMemberStatus(studyGroupId, memberId);
 
-    return StudyGroupDetailResponse.from(group, replyMap);
+    return StudyGroupDetailResponse.from(group, replyMap, memberStatus);
+  }
+
+  public StudyGroupMemberStatus getMemberStatus(Long studyGroupId, Long memberId) {
+    Optional<StudyGroupMember> memberOpt =
+        studyGroupMemberRepository.findByStudyGroupIdAndMemberId(studyGroupId, memberId);
+
+    return memberOpt.map(studyGroupMember -> studyGroupMember.getIsAllowed()
+        ? StudyGroupMemberStatus.APPROVED
+        : StudyGroupMemberStatus.PENDING).orElse(StudyGroupMemberStatus.NOT_APPLIED);
+
   }
 
 

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceDetailsTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceDetailsTest.java
@@ -76,7 +76,7 @@ class StudyGroupServiceDetailsTest extends IntegrationTestSupport {
   @DisplayName("스터디 그룹 ID로 상세 조회하면 작성자, 멤버, 댓글이 모두 포함된다")
   void getStudyGroupDetail_success() {
     // when
-    StudyGroupDetailResponse result = studyGroupService.getStudyGroupDetail(studyGroupId);
+    StudyGroupDetailResponse result = studyGroupService.getStudyGroupDetail(studyGroupId, 0L);
 
     // then
     assertThat(result.getTitle()).isEqualTo("통합테스트 스터디");
@@ -90,7 +90,7 @@ class StudyGroupServiceDetailsTest extends IntegrationTestSupport {
   @DisplayName("스터디 그룹 ID가 존재하지 않으면 예외가 발생한다")
   void getStudyGroupDetail_notFound() {
     // when & then
-    assertThatThrownBy(() -> studyGroupService.getStudyGroupDetail(-1L))
+    assertThatThrownBy(() -> studyGroupService.getStudyGroupDetail(-1L, 0L))
         .isInstanceOf(StudyGroupNotFoundException.class);
   }
 }


### PR DESCRIPTION
## 📌 개요
* 스터디 상세 조회 시 현재 로그인한 사용자의 참여 상태(`미신청`, `신청 완료`, `참여 중`)를 명확히 판단하고 클라이언트에 전달할 수 있도록 설계 개선.

## 🛠️ 작업 내용
- [x] StudyGroupMemberStatus enum 생성 (NOT_APPLIED, PENDING, APPROVED)
- [x] StudyGroupService에 참여 상태 판별 메서드 추가 (`getMemberStatus`)
- [x] StudyGroupMemberRepository에 `findByStudyGroupIdAndMemberId` 메서드 추가
- [x] StudyGroupDetailResponse에 `memberStatus` 필드 추가 및 응답에 포함
- [x] Boolean 기반의 단순 승인 여부를 의미있는 상태로 추상화

### (스터디 참여 상태 도출 로직 추가)

* 기존에는 단순히 `isAllowed`로만 참여 여부를 구분했으나, 신청 여부 자체를 구분하지 못하는 문제가 있었음
* 이를 해결하기 위해 `StudyGroupMemberStatus` enum을 도입하여 다음 3단계로 상태를 분리:
  - 미신청: 해당 스터디에 아무 기록 없음
  - 신청 완료: 신청했으나 승인되지 않음
  - 참여 중: 신청 및 승인 완료
* 서비스 계층에서 `Optional<StudyGroupMember>`를 조회한 뒤 상태를 판단하여 `StudyGroupDetailResponse`로 전달

## 📌 차후 계획 (Optional)

* 스터디 상세 페이지에서 버튼 UI 상태 (예: 신청하기/신청 완료/참여 중 등)를 `memberStatus` 값 기반으로 렌더링할 수 있도록 프론트엔드 연동 예정
* 관리자가 참여자 승인 시 상태 변경 관련 이벤트 트리거 기능 추가 가능성 검토

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

* 테스트한 내용:
  - `StudyGroupMember`가 존재하지 않는 경우 `NOT_APPLIED`로 응답되는지 확인
  - 존재하지만 `isAllowed = false`일 경우 `PENDING`으로 응답되는지 확인
  - `isAllowed = true`일 경우 `APPROVED`로 응답되는지 확인

### 📌 기타 참고 사항

- 단순한 Boolean 대신 Enum으로 분리하여 유지보수성과 확장성 증가
- 추후 상태 변경 시점(예: 승인, 거절, 취소 등) 관리도 용이해짐

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

Closes #307