### PR TITLE
[Feature] 일정 수정 시 멤버 참석 여부 초기화 및 대기 상태 처리 개선

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/entity/MemberStudySchedule.java
@@ -59,5 +59,4 @@ public class MemberStudySchedule extends BaseEntity {
     public void updateMemo(String memo) {
         this.memo = memo;
     }
-
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/repository/MemberStudyScheduleRepository.java
@@ -21,4 +21,6 @@ public interface MemberStudyScheduleRepository extends JpaRepository<MemberStudy
     WHERE mss.member.id = :memberId
     """)
     List<MemberStudySchedule> findAllByMemberId(@Param("memberId") Long memberId);
+
+    List<MemberStudySchedule> findByStudyScheduleId(Long studyScheduleId);
 }

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/MemberStudyScheduleService.java
@@ -42,6 +42,8 @@ public class MemberStudyScheduleService {
                 memberStudySchedule.updateImportant(false);
                 memberStudySchedule.updateMemo(null);
             }
+        } else {
+            memberStudySchedule.updateAvailable(null);
         }
 
         if (requestDto.getIsImportant() != null) {

--- a/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
+++ b/src/main/java/com/samsamhajo/deepground/calendar/service/StudyScheduleService.java
@@ -113,6 +113,11 @@ public class StudyScheduleService {
                 requestDto.getLocation()
         );
 
+        List<MemberStudySchedule> memberSchedules = memberStudyScheduleRepository.findByStudyScheduleId(scheduleId);
+        for (MemberStudySchedule memberSchedule : memberSchedules) {
+            memberSchedule.updateAvailable(null);
+        }
+
         return StudyScheduleResponseDto.from(studySchedule);
     }
 


### PR DESCRIPTION
## 📌 개요

스터디 일정 수정 시 멤버들의 참석 여부를 초기화하고, 멤버 개별 일정 수정 로직 개선

## 🛠️ 작업 내용
- 스터디 일정 수정 시 해당 일정에 속한 멤버 스터디 일정의 isAvailable을 null로 초기화

 - 멤버 스터디 일정 개별 수정 시 isAvailable이 null인 경우도 정상 처리되도록 로직 개선

 - 기존에 누락됐던 else 구문을 추가하여 null 값 업데이트 반영



## 📌 차후 계획 (Optional)

* (작업한 코드가 추후 우리 프로젝트에 어떤 영향을 끼칠지, 앞으로 PR계획을 설명해주세요)


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

closes #321 