### PR TITLE
[Feature] 스터디 그룹 생성 시 TechStack 연관관계 리팩토링 및 조회 기능 개선

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/controller/StudyGroupController.java
@@ -71,7 +71,7 @@ public class StudyGroupController {
   public ResponseEntity<SuccessResponse<?>> searchStudyGroups(
       @ModelAttribute StudyGroupSearchRequest request
   ) {
-    GlobalLogger.info("스터디 목록 검색 요청", request.getKeyword(), request.getGroupStatus(), request.getTechTags());
+    GlobalLogger.info("스터디 목록 검색 요청", request.getKeyword(), request.getGroupStatus(), request.getTechStackNames());
 
     var response = studyGroupService.searchStudyGroups(request);
     return ResponseEntity

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateRequest.java
@@ -2,6 +2,7 @@ package com.samsamhajo.deepground.studyGroup.dto;
 
 import com.samsamhajo.deepground.studyGroup.entity.TechTag;
 import jakarta.validation.constraints.*;
+import java.util.List;
 import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -44,5 +45,7 @@ public class StudyGroupCreateRequest {
 
   private String studyLocation; // isOffline이 true일 때만 필요
 
-  private Set<TechTag> techTags;
+  @NotNull(message = "기술 스택은 필수입니다.")
+  @Size(min = 1, message = "최소 1개 이상의 기술 스택을 선택해주세요.")
+  private List<String> techStackNames;
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateResponse.java
@@ -4,6 +4,7 @@ import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupTechTag;
 import com.samsamhajo.deepground.studyGroup.entity.TechTag;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,7 +17,7 @@ public class StudyGroupCreateResponse {
   private String explanation;
   private Boolean isOffline;
   private String studyLocation;
-  private Set<StudyGroupTechTag> techTags;
+  private Set<TechTagDto> techTags;
 
   public static StudyGroupCreateResponse from(StudyGroup group) {
     return StudyGroupCreateResponse.builder()
@@ -25,7 +26,12 @@ public class StudyGroupCreateResponse {
         .explanation(group.getExplanation())
         .isOffline(group.getIsOffline())
         .studyLocation(group.getStudyLocation())
-        .techTags(group.getStudyGroupTechTags())
+        .techTags(
+            group.getStudyGroupTechTags().stream()
+                .map(StudyGroupTechTag::getTechStack)
+                .map(TechTagDto::from)
+                .collect(Collectors.toSet())
+        )
         .build();
   }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupCreateResponse.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.studyGroup.dto;
 
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupTechTag;
 import com.samsamhajo.deepground.studyGroup.entity.TechTag;
 import java.util.Set;
 import lombok.Builder;
@@ -15,7 +16,7 @@ public class StudyGroupCreateResponse {
   private String explanation;
   private Boolean isOffline;
   private String studyLocation;
-  private Set<TechTag> techTags;
+  private Set<StudyGroupTechTag> techTags;
 
   public static StudyGroupCreateResponse from(StudyGroup group) {
     return StudyGroupCreateResponse.builder()
@@ -24,7 +25,7 @@ public class StudyGroupCreateResponse {
         .explanation(group.getExplanation())
         .isOffline(group.getIsOffline())
         .studyLocation(group.getStudyLocation())
-        .techTags(group.getTechTags())
+        .techTags(group.getStudyGroupTechTags())
         .build();
   }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
@@ -3,6 +3,7 @@ package com.samsamhajo.deepground.studyGroup.dto;
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupTechTag;
 import com.samsamhajo.deepground.studyGroup.entity.TechTag;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +21,7 @@ public class StudyGroupResponse {
   private String period;
   private String recruitmentPeriod;
   private GroupStatus groupStatus;
-  private Set<TechTag> tags;
+  private Set<StudyGroupTechTag> tags;
   private Integer maxMembers;
   private Integer currentMembers;
   private OrganizerDto organizer;
@@ -45,7 +46,7 @@ public class StudyGroupResponse {
         .description(group.getExplanation())
         .period(group.getStudyStartDate().format(formatter) + " ~ " + group.getStudyEndDate().format(formatter))
         .recruitmentPeriod(group.getRecruitStartDate().format(formatter) + " ~ " + group.getRecruitEndDate().format(formatter))
-        .tags(group.getTechTags())
+        .tags(group.getStudyGroupTechTags())
         .maxMembers(group.getGroupMemberCount())
         .currentMembers(group.getMembers().size())
         .groupStatus(group.getGroupStatus())

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupResponse.java
@@ -5,6 +5,7 @@ import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
 import com.samsamhajo.deepground.studyGroup.entity.StudyGroupTechTag;
 import com.samsamhajo.deepground.studyGroup.entity.TechTag;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,7 +22,7 @@ public class StudyGroupResponse {
   private String period;
   private String recruitmentPeriod;
   private GroupStatus groupStatus;
-  private Set<StudyGroupTechTag> tags;
+  private Set<TechTagDto> tags;
   private Integer maxMembers;
   private Integer currentMembers;
   private OrganizerDto organizer;
@@ -40,13 +41,18 @@ public class StudyGroupResponse {
 
     Member creator = group.getCreator();
 
+    Set<TechTagDto> techTags = group.getStudyGroupTechTags().stream()
+        .map(StudyGroupTechTag::getTechStack)
+        .map(techStack -> new TechTagDto(techStack.getId(), techStack.getName()))
+        .collect(Collectors.toSet());
+
     return StudyGroupResponse.builder()
         .id(group.getId())
         .title(group.getTitle())
         .description(group.getExplanation())
         .period(group.getStudyStartDate().format(formatter) + " ~ " + group.getStudyEndDate().format(formatter))
         .recruitmentPeriod(group.getRecruitStartDate().format(formatter) + " ~ " + group.getRecruitEndDate().format(formatter))
-        .tags(group.getStudyGroupTechTags())
+        .tags(techTags)
         .maxMembers(group.getGroupMemberCount())
         .currentMembers(group.getMembers().size())
         .groupStatus(group.getGroupStatus())

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupSearchRequest.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/StudyGroupSearchRequest.java
@@ -1,13 +1,13 @@
 package com.samsamhajo.deepground.studyGroup.dto;
 
 import com.samsamhajo.deepground.studyGroup.entity.GroupStatus;
-import com.samsamhajo.deepground.studyGroup.entity.TechTag;
-import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+
+import java.util.List;
 
 @Getter
 public class StudyGroupSearchRequest {
@@ -16,15 +16,21 @@ public class StudyGroupSearchRequest {
   private final GroupStatus groupStatus;
   private final int page;
   private final int size;
-  private final Set<TechTag> techTags; // 추가됨
+  private final List<String> techStackNames;
 
   @Builder
-  public StudyGroupSearchRequest(String keyword, GroupStatus groupStatus, int page, int size, Set<TechTag> techTags) {
+  public StudyGroupSearchRequest(
+      String keyword,
+      GroupStatus groupStatus,
+      int page,
+      int size,
+      List<String> techStackNames
+  ) {
     this.keyword = keyword;
     this.groupStatus = groupStatus;
     this.page = page;
     this.size = size;
-    this.techTags = techTags;
+    this.techStackNames = techStackNames;
   }
 
   public Pageable toPageable() {

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/dto/TechTagDto.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/dto/TechTagDto.java
@@ -1,0 +1,15 @@
+package com.samsamhajo.deepground.studyGroup.dto;
+
+import com.samsamhajo.deepground.techStack.entity.TechStack;
+import lombok.Builder;
+
+@Builder
+public record TechTagDto(Long id, String name) {
+
+  public static TechTagDto from(TechStack techStack) {
+    return TechTagDto.builder()
+        .id(techStack.getId())
+        .name(techStack.getName())
+        .build();
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -56,14 +56,12 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "study_location")
     private String studyLocation;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    @Enumerated(EnumType.STRING)
-    private Set<TechTag> techTags = new HashSet<>();
+    @OneToMany(mappedBy = "studyGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<StudyGroupTechTag> studyGroupTechTags = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "member_id", nullable = false)
     private Member creator;
-
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id", nullable = false)
@@ -79,7 +77,7 @@ public class StudyGroup extends BaseEntity {
         ChatRoom chatRoom, String title, String explanation,
         LocalDate studyStartDate, LocalDate studyEndDate,
         LocalDate recruitStartDate, LocalDate recruitEndDate,
-        Integer groupMemberCount, Member member, Boolean isOffline, String studyLocation, Set<TechTag> techTags
+        Integer groupMemberCount, Member member, Boolean isOffline, String studyLocation
     ) {
         this.chatRoom = chatRoom;
         this.title = title;
@@ -92,24 +90,27 @@ public class StudyGroup extends BaseEntity {
         this.creator = member;
         this.isOffline = isOffline;
         this.studyLocation = studyLocation;
-        this.techTags = techTags;
     }
 
-  public static StudyGroup of(
+    public static StudyGroup of(
         ChatRoom chatRoom, String title, String explanation,
         LocalDate studyStartDate, LocalDate studyEndDate,
         LocalDate recruitStartDate, LocalDate recruitEndDate,
-        Integer groupMemberCount, Member member, Boolean isOffline, String studyLocation, Set<TechTag> techTags
+        Integer groupMemberCount, Member member, Boolean isOffline, String studyLocation
     ) {
         return new StudyGroup(
             chatRoom, title, explanation,
             studyStartDate, studyEndDate,
             recruitStartDate, recruitEndDate,
-            groupMemberCount, member, isOffline, studyLocation, techTags
+            groupMemberCount, member, isOffline, studyLocation
         );
     }
 
     public void changeGroupStatus(GroupStatus newStatus) {
         this.groupStatus = newStatus;
+    }
+
+    public void addTechTag(StudyGroupTechTag techTag) {
+        this.studyGroupTechTags.add(techTag);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroup.java
@@ -56,7 +56,7 @@ public class StudyGroup extends BaseEntity {
     @Column(name = "study_location")
     private String studyLocation;
 
-    @OneToMany(mappedBy = "studyGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "studyGroup", orphanRemoval = true)
     private Set<StudyGroupTechTag> studyGroupTechTags = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupTechTag.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupTechTag.java
@@ -1,0 +1,37 @@
+package com.samsamhajo.deepground.studyGroup.entity;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroup;
+import com.samsamhajo.deepground.techStack.entity.TechStack;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "study_group_tech_tag")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyGroupTechTag {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "study_group_tech_tag_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "study_group_id", nullable = false)
+  private StudyGroup studyGroup;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "tech_stack_id", nullable = false)
+  private TechStack techStack;
+
+  private StudyGroupTechTag(StudyGroup studyGroup, TechStack techStack) {
+    this.studyGroup = studyGroup;
+    this.techStack = techStack;
+  }
+
+  public static StudyGroupTechTag of(StudyGroup studyGroup, TechStack techStack) {
+    return new StudyGroupTechTag(studyGroup, techStack);
+  }
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupTechTag.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/entity/StudyGroupTechTag.java
@@ -32,6 +32,8 @@ public class StudyGroupTechTag {
   }
 
   public static StudyGroupTechTag of(StudyGroup studyGroup, TechStack techStack) {
-    return new StudyGroupTechTag(studyGroup, techStack);
+    StudyGroupTechTag link = new StudyGroupTechTag(studyGroup, techStack);
+    studyGroup.addTechTag(link);
+    return link;
   }
 }

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -18,8 +18,8 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
   @Query("""
   SELECT DISTINCT sg FROM StudyGroup sg
   LEFT JOIN FETCH sg.creator
-  LEFT JOIN sg.studyGroupTechTags sgt
-  LEFT JOIN sgt.techStack ts
+  LEFT JOIN FETCH sg.studyGroupTechTags sgt
+  LEFT JOIN FETCH sgt.techStack ts
   WHERE (:status IS NULL OR sg.groupStatus = :status)
     AND (
         (:keyword IS NULL OR LOWER(sg.title) LIKE LOWER(CONCAT('%', :keyword, '%')))

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupRepository.java
@@ -16,20 +16,21 @@ import org.springframework.data.repository.query.Param;
 public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
 
   @Query("""
-    SELECT DISTINCT sg FROM StudyGroup sg
-    LEFT JOIN FETCH sg.creator
-    LEFT JOIN sg.techTags tag
-    WHERE (:status IS NULL OR sg.groupStatus = :status)
-      AND (
-          (:keyword IS NULL OR LOWER(sg.title) LIKE LOWER(CONCAT('%', :keyword, '%')))
-          OR (:keyword IS NULL OR LOWER(sg.explanation) LIKE LOWER(CONCAT('%', :keyword, '%')))
-      )
-      AND (:tags IS NULL OR tag IN :tags)
+  SELECT DISTINCT sg FROM StudyGroup sg
+  LEFT JOIN FETCH sg.creator
+  LEFT JOIN sg.studyGroupTechTags sgt
+  LEFT JOIN sgt.techStack ts
+  WHERE (:status IS NULL OR sg.groupStatus = :status)
+    AND (
+        (:keyword IS NULL OR LOWER(sg.title) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        OR (:keyword IS NULL OR LOWER(sg.explanation) LIKE LOWER(CONCAT('%', :keyword, '%')))
+    )
+    AND (:stackNames IS NULL OR ts.name IN :stackNames)
 """)
   Page<StudyGroup> searchWithFilters(
       @Param("status") GroupStatus status,
       @Param("keyword") String keyword,
-      @Param("tags") List<String> tags,
+      @Param("stackNames") List<String> stackNames,
       Pageable pageable
   );
 

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupTechTagRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/repository/StudyGroupTechTagRepository.java
@@ -1,0 +1,10 @@
+package com.samsamhajo.deepground.studyGroup.repository;
+
+import com.samsamhajo.deepground.studyGroup.entity.StudyGroupTechTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyGroupTechTagRepository extends JpaRepository<StudyGroupTechTag, Long> {
+
+}

--- a/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
+++ b/src/main/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupService.java
@@ -12,6 +12,7 @@ import com.samsamhajo.deepground.studyGroup.entity.StudyGroupTechTag;
 import com.samsamhajo.deepground.studyGroup.exception.StudyGroupNotFoundException;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupResponse;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupSearchRequest;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupTechTagRepository;
 import com.samsamhajo.deepground.techStack.entity.TechStack;
 import com.samsamhajo.deepground.techStack.repository.TechStackRepository;
 import java.util.stream.Collectors;
@@ -40,6 +41,7 @@ public class StudyGroupService {
   private final StudyGroupMemberRepository studyGroupMemberRepository;
   private final ChatRoomService chatRoomService;
   private final TechStackRepository techStackRepository;
+  private final StudyGroupTechTagRepository studyGroupTechTagRepository;
 
 
   @Transactional
@@ -101,15 +103,15 @@ public class StudyGroupService {
         request.getStudyLocation()
     );
 
-
     StudyGroup savedGroup = studyGroupRepository.save(studyGroup);
 
     List<String> stackNames = request.getTechStackNames();
+
     if (stackNames != null && !stackNames.isEmpty()) {
-      List<TechStack> techStacks = techStackRepository.findAllByNameIn(stackNames);
+      List<TechStack> techStacks = techStackRepository.findByNames(stackNames);
       for (TechStack techStack : techStacks) {
         StudyGroupTechTag link = StudyGroupTechTag.of(savedGroup, techStack);
-        savedGroup.addTechTag(link);
+        studyGroupTechTagRepository.save(link);
       }
     }
 

--- a/src/main/java/com/samsamhajo/deepground/techStack/repository/TechStackRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/techStack/repository/TechStackRepository.java
@@ -1,6 +1,7 @@
 package com.samsamhajo.deepground.techStack.repository;
 
 import com.samsamhajo.deepground.techStack.entity.TechStack;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
     Optional<TechStack> findByName(String name);
+
+    List<TechStack> findAllByNameIn(List<String> names);
 }

--- a/src/main/java/com/samsamhajo/deepground/techStack/repository/TechStackRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/techStack/repository/TechStackRepository.java
@@ -3,6 +3,8 @@ package com.samsamhajo.deepground.techStack.repository;
 import com.samsamhajo.deepground.techStack.entity.TechStack;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,5 +13,6 @@ import java.util.Optional;
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
     Optional<TechStack> findByName(String name);
 
-    List<TechStack> findAllByNameIn(List<String> names);
+    @Query("SELECT t FROM TechStack t WHERE t.name IN :names")
+    List<TechStack> findByNames(@Param("names") List<String> names);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,7 @@ spring:
         format_sql: true
         use_sql_comments: true
     open-in-view: false
-    show-sql: true
+    show-sql: false
   data:
     redis:
       host: ${REDIS_HOST}

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceTest.java
@@ -9,6 +9,7 @@ import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateRequest;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateResponse;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import com.samsamhajo.deepground.techStack.repository.TechStackRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +24,7 @@ public class StudyGroupServiceTest {
     private StudyGroupMemberRepository studyGroupMemberRepository;
     private ChatRoomService chatRoomService;
     private StudyGroupService studyGroupService;
+    private TechStackRepository techStackRepository;
 
     @BeforeEach
     void setUp() {
@@ -32,7 +34,8 @@ public class StudyGroupServiceTest {
         studyGroupService = new StudyGroupService(
                 studyGroupRepository,
                 studyGroupMemberRepository,
-                chatRoomService
+                chatRoomService,
+                techStackRepository
         );
     }
 

--- a/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/studyGroup/service/StudyGroupServiceTest.java
@@ -9,6 +9,7 @@ import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateRequest;
 import com.samsamhajo.deepground.studyGroup.dto.StudyGroupCreateResponse;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupMemberRepository;
 import com.samsamhajo.deepground.studyGroup.repository.StudyGroupRepository;
+import com.samsamhajo.deepground.studyGroup.repository.StudyGroupTechTagRepository;
 import com.samsamhajo.deepground.techStack.repository.TechStackRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ public class StudyGroupServiceTest {
     private ChatRoomService chatRoomService;
     private StudyGroupService studyGroupService;
     private TechStackRepository techStackRepository;
+    private StudyGroupTechTagRepository studyGroupTechTagRepository;
 
     @BeforeEach
     void setUp() {
@@ -35,7 +37,8 @@ public class StudyGroupServiceTest {
                 studyGroupRepository,
                 studyGroupMemberRepository,
                 chatRoomService,
-                techStackRepository
+                techStackRepository,
+                studyGroupTechTagRepository
         );
     }
 


### PR DESCRIPTION
## 📌 개요  
기존에는 `TechTag` enum을 사용해 스터디 그룹의 기술 스택을 관리하고 있었지만, 이를 제거하고 `StudyGroup` ↔ `TechStack` 간 다대다 매핑을 중간 엔티티 `StudyGroupTechTag`를 통해 일대다-다대일 방식으로 리팩토링했습니다.  
또한 기술 스택 필터링을 포함한 스터디 그룹 조회 기능을 개선했습니다.

---

## 🛠️ 작업 내용  
- [x] `TechTag` enum 제거 및 DB 기반 `TechStack` 엔티티로 변경
- [x] 다대다 매핑을 피하기 위한 `StudyGroupTechTag` 중간 엔티티 생성
- [x] `StudyGroup.createStudyGroup()` 내부 로직에서 `StudyGroupTechTag` 생성 및 저장 명시 처리
- [x] `StudyGroupCreateResponse`, `StudyGroupResponse` DTO에서 `TechTag` → `TechTagDto`로 구조 변경
- [x] `StudyGroupRepository.searchWithFilters()`에서 기술 스택 이름 리스트로 필터링 기능 추가 (JPQL)
- [x] LazyInitializationException 발생 문제 해결 (명시적 save 및 DTO 전환 방식 수정)

### 🧩 StudyGroup 생성
* 생성 시 요청받은 기술 스택 이름 리스트를 통해 `TechStack`을 조회하고, 중간 테이블에 매핑 정보를 저장
* cascade 대신 명시적 save 방식으로 `StudyGroupTechTag` 저장

### 🧩 스터디 그룹 조회
* 키워드, 모집 상태, 기술 스택 이름 리스트를 기준으로 필터링 가능
* `StudyGroupResponse`에 포함된 기술 스택도 DTO 형태로 반환

---

## 📌 차후 계획 (Optional)  
- 기술 스택 선택 시 자동 완성 및 유효성 검사를 위한 API 구현 예정  
- `StudyGroupResponse`에 기술 스택 카테고리별 그룹핑 추가 가능성 검토 중

---

## 📌 테스트 케이스  
- [x] 스터디 그룹 생성 시 전달된 기술 스택이 정확히 저장되는지 확인 (DB 조회 및 로그 확인)
- [x] 스터디 그룹 조회 시 등록된 기술 스택이 함께 반환되는지 확인
- [x] 기술 스택 이름 기준 필터링 검색이 정확히 동작하는지 확인
- [x] 존재하지 않는 스택 이름이 포함된 경우 처리 확인

---

## 📌 기타 참고 사항  
- `StudyGroupTechTag.of()` 메서드 내부에서 `StudyGroup.addTechTag()` 호출되도록 구성
- `StudyGroupCreateResponse`, `StudyGroupResponse`에서 `Set<StudyGroupTechTag>` → `Set<TechTagDto>`로 명확히 매핑 처리
- `LazyInitializationException` 방지를 위해 DTO로 전환 시점에서 필요한 관계는 모두 조회되도록 설정

Closes #332